### PR TITLE
Remove time exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.2.2
+======
+* Completely removed 30 second exclude range - it was excluding players that are active, and none of the players being excluded are inactive.
+
 v1.2.1
 ======
 * Fixed issue with 'active' players not being defined as active because their profile had been updated in the 5 mins before the run (we built this is in as a feature to stop us defining inactive players as active)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,8 @@ try {
     }
 
     stage ('Generate Artifacts') {
+      pom = readMavenPom file: 'pom.xml'
+      $POM_VERSION = pom.version
       step([$class: 'JavadocArchiver', javadocDir: 'target/site/apidocs'])
       sh 'mkdir - p target/release'
       sh 'cp target/*dependencies.jar target/release/XIVStats-Gatherer-Java.jar'

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ffxivcensus.gatherer</groupId>
     <artifactId>XIVStats-Gatherer-Java</artifactId>
-    <version>v1.2.0</version>
+    <version>v1.2.2</version>
     <name>XIVStats Lodestone Gatherer</name>
     <url>https://github.com/xivstats</url>
 

--- a/src/main/java/com/ffxivcensus/gatherer/Player.java
+++ b/src/main/java/com/ffxivcensus/gatherer/Player.java
@@ -1911,14 +1911,9 @@ public class Player {
 
         Calendar date = Calendar.getInstance();
         long t= date.getTimeInMillis();
-        Date nowMinusExcludeRange =new Date(t - (EXCLUDE_RANGE * 30000));
 
         Date nowMinusIncludeRange = new Date(t - (ACTIVITY_RANGE_DAYS * ONE_DAY_IN_MILLIS));
-        if(this.dateImgLastModified.after(nowMinusExcludeRange)) { //If the date modified is inside the exclude range
-            //Reset the last modified date to epoch because we aren't considering it valid
-            this.dateImgLastModified = new Date(0);
-            return false;
-        } else return this.dateImgLastModified.after(nowMinusIncludeRange); //If the date occurs between the include range and now, then return true. Else false
+        return this.dateImgLastModified.after(nowMinusIncludeRange); //If the date occurs between the include range and now, then return true. Else false
     }
 
     /**


### PR DESCRIPTION
I've removed the 30 second exclude window because based on our testing we're excluding players who are active, and there's no 'inactive' players being excluded. These players had just had their profiles updated in the 30 seconds before parse - it was thought that we'd get uncached hits in this range - but it appears not.

It would probably not be necessary to re-run; you can probably just drop the players who have been mis-interpreted and re-run those id's specifically: find them with 

```sql
SELECT * FROM tblplayers WHERE date_active NOT LIKE '%20%';
```
