### PR TITLE
v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v1.2.2
+======
+* Completely removed 30 second exclude range - it was excluding players that are active, and none of the players being excluded are inactive.
+
 v1.2.1
 ======
 * Fixed issue with 'active' players not being defined as active because their profile had been updated in the 5 mins before the run (we built this is in as a feature to stop us defining inactive players as active)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ v1.2.2
 * Added parsing for owners of Heavensward Lore book 2
 * Added parsing for owners of Topaz Carbuncle plush
 * Added parsing for owners of Emerald Carbuncle plush
+* Added parsing for characters who have completed Moogle Beast Tribe to Rank 7
 
 v1.2.1
 ======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ v1.3.0
 * Added parsing for owners of Emerald Carbuncle plush
 * Added parsing for characters who have completed Moogle Beast Tribe to Rank 7
 * Added parsing for characters who have completed Vanu Vanu Beast Tribe to Rank 7
+* Added parsing for characters who have completed Vath Beast Tribe to Rank 7
 
 v1.2.1
 ======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 v1.2.2
 ======
 * Completely removed 30 second exclude range - it was excluding players that are active, and none of the players being excluded are inactive.
+* DB field `artbook` renamed to `arrartbook`
+* Added parsing for owners of Encyclopedia Eorzea
+* Added parsing for owners of Heavensward Lore book 1
+* Added parsing for owners of Heavensward Lore book 2
+* Added parsing for owners of Topaz Carbuncle plush
+* Added parsing for owners of Emerald Carbuncle plush
 
 v1.2.1
 ======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ v1.3.0
 * Added parsing for characters who have completed Moogle Beast Tribe to Rank 7
 * Added parsing for characters who have completed Vanu Vanu Beast Tribe to Rank 7
 * Added parsing for characters who have completed Vath Beast Tribe to Rank 7
+* [Bugfix] 180 days and 90 day subscriptions were returing wrong value
 
 v1.2.1
 ======

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-v1.2.2
+v1.3.0
 ======
-* Completely removed 30 second exclude range - it was excluding players that are active, and none of the players being excluded are inactive.
+* Completely removed 30 second exclude range from image reader - it was excluding players that are active, and none of the players being excluded are inactive.
 * DB field `artbook` renamed to `arrartbook`
 * Added parsing for owners of Encyclopedia Eorzea
 * Added parsing for owners of Heavensward Lore book 1
@@ -8,6 +8,7 @@ v1.2.2
 * Added parsing for owners of Topaz Carbuncle plush
 * Added parsing for owners of Emerald Carbuncle plush
 * Added parsing for characters who have completed Moogle Beast Tribe to Rank 7
+* Added parsing for characters who have completed Vanu Vanu Beast Tribe to Rank 7
 
 v1.2.1
 ======

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,8 @@ try {
     }
 
     stage ('Generate Artifacts') {
+      pom = readMavenPom file: 'pom.xml'
+      $POM_VERSION = pom.version
       step([$class: 'JavadocArchiver', javadocDir: 'target/site/apidocs'])
       sh 'mkdir - p target/release'
       sh 'cp target/*dependencies.jar target/release/XIVStats-Gatherer-Java.jar'

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ The database table ```tblplayers``` has the following structure:
 |amaljaa               |bit      |Mount - Cavalry Drake           |
 |sylph                 |bit      |Mount - Laurel Goobbue          |
 |moogle                |bit      |Mount - Cloud Mallow            |
+|vanuvanu              |bit      |Mount - Sanuwa                  |
 |hw_complete           |bit      |Mount - Midgardsormr            |
 |hw_31_complete        |bit      |Minion - Wind-up Haurchefant    |
 |hw_33_complete        |bit      |Minion - Wind-up Aymeric        |

--- a/README.md
+++ b/README.md
@@ -154,7 +154,10 @@ The database table ```tblplayers``` has the following structure:
 |p960days              |bit      |Minion - Wind-up Firion         |
 |prearr                |bit      |Minion - Cait Sith Doll         |
 |prehw                 |bit      |Minion - Chocobo Chick Courier  |
-|artbook               |bit      |Minion - Model Enterprise       |
+|arrartbook            |bit      |Minion - Model Enterprise       |
+|hwartbookone          |bit      |Minion - Wind-Up Relm           |
+|hwartbooktw           |bit      |Minion - Wind-Up Hraesvelgr     |
+|hasencyclopedia       |bit      |Minion - Namingway              |
 |beforemeteor          |bit      |Minion - Wind-up Dalamud        |
 |beforethefall         |bit      |Minion - Set Of Primogs         |
 |soundtrack            |bit      |Minion - Wind-up Bahamut        |
@@ -163,6 +166,8 @@ The database table ```tblplayers``` has the following structure:
 |arr_25_complete       |bit      |Minion - Midgardsormr           |
 |comm50                |bit      |Minion - Princely Hatchling     |
 |moogleplush           |bit      |Minion - Wind-up Delivery Moogle|
+|topazcarubuncleplush  |bit      |Minion - Heliodor Carbuncle     |
+|emeraldcarbuncleplush |bit      |Minion - Peridot Carbuncle      |
 |hildibrand            |bit      |Minion - Wind-up Gentleman      |
 |ps4collectors         |bit      |Minion - Wind-up Moogle         |
 |dideternalbond        |bit      |Mount - Ceremony Chocobo        |

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ The database table ```tblplayers``` has the following structure:
 |sahagin               |bit      |Mount - Cavalry Elbst           |
 |amaljaa               |bit      |Mount - Cavalry Drake           |
 |sylph                 |bit      |Mount - Laurel Goobbue          |
+|moogle                |bit      |Mount - Cloud Mallow            |
 |hw_complete           |bit      |Mount - Midgardsormr            |
 |hw_31_complete        |bit      |Minion - Wind-up Haurchefant    |
 |hw_33_complete        |bit      |Minion - Wind-up Aymeric        |

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The database table ```tblplayers``` has the following structure:
 |sylph                 |bit      |Mount - Laurel Goobbue          |
 |moogle                |bit      |Mount - Cloud Mallow            |
 |vanuvanu              |bit      |Mount - Sanuwa                  |
+|vath                  |bit      |Mount - Kongamato               |
 |hw_complete           |bit      |Mount - Midgardsormr            |
 |hw_31_complete        |bit      |Minion - Wind-up Haurchefant    |
 |hw_33_complete        |bit      |Minion - Wind-up Aymeric        |

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ffxivcensus.gatherer</groupId>
     <artifactId>XIVStats-Gatherer-Java</artifactId>
-    <version>v1.2.2</version>
+    <version>v1.3.0</version>
     <name>XIVStats Lodestone Gatherer</name>
     <url>https://github.com/xivstats</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ffxivcensus.gatherer</groupId>
     <artifactId>XIVStats-Gatherer-Java</artifactId>
-    <version>v1.2.0</version>
+    <version>v1.2.2</version>
     <name>XIVStats Lodestone Gatherer</name>
     <url>https://github.com/xivstats</url>
 

--- a/src/main/java/com/ffxivcensus/gatherer/GathererController.java
+++ b/src/main/java/com/ffxivcensus/gatherer/GathererController.java
@@ -347,7 +347,7 @@ public class GathererController {
                 sbSQL.append("soundtrack BIT,saweternalbond BIT,sightseeing BIT,comm50 BIT,moogleplush BIT,");
                 sbSQL.append("topazcarubuncleplush BIT,emeraldcarbuncleplush BIT,");
                 sbSQL.append("hildibrand BIT, dideternalbond BIT, arrcollector BIT,");
-                sbSQL.append("kobold BIT, sahagin BIT, amaljaa BIT, sylph BIT, moogle BIT, vanuvanu BIT, ");
+                sbSQL.append("kobold BIT, sahagin BIT, amaljaa BIT, sylph BIT, moogle BIT, vanuvanu BIT, vath BIT, ");
                 sbSQL.append("arr_25_complete BIT,hw_complete BIT, hw_31_complete BIT, hw_33_complete BIT, legacy_player BIT");
             }
             if (this.storeMounts) {
@@ -509,12 +509,12 @@ public class GathererController {
                                 + player.getBitHasEmeraldCarbunclePlush() + ",");
 
                 sbFields.append("hildibrand, ps4collectors, dideternalbond, arrcollector, kobold, sahagin, amaljaa, "
-                                + "sylph, moogle, vanuvanu, hw_complete, hw_31_complete, hw_33_complete, legacy_player");
+                                + "sylph, moogle, vanuvanu, vath, hw_complete, hw_31_complete, hw_33_complete, legacy_player");
                 sbValues.append(player.getBitHasCompletedHildibrand() + "," + player.getBitHasPS4Collectors() + ","
                         + player.getBitHasEternalBond() + "," + player.getBitHasARRCollectors() + ","
-                        + player.getBitHasKobold() + "," + player.getBitHasSahagin() + "," + player.getBitHasAmaljaa()
-                        + "," + player.getBitHasSylph() + "," + player.getBitHasMoogle() + "," + player.getBitHasVanuVanu()
-                        + "," + player.getBitHasCompletedHW() + ","
+                        + player.getBitHasKobold() + "," + player.getBitHasSahagin() + "," + player.getBitHasAmaljaa() + ","
+                        + player.getBitHasSylph() + "," + player.getBitHasMoogle() + "," + player.getBitHasVanuVanu() + ","
+                        + player.getBitHasVath() + "," + player.getBitHasCompletedHW() + ","
                         + player.getBitHasCompleted3pt1() + "," + player.getBitHasCompleted3pt3() + ","
                         + player.getBitIsLegacyPlayer());
 

--- a/src/main/java/com/ffxivcensus/gatherer/GathererController.java
+++ b/src/main/java/com/ffxivcensus/gatherer/GathererController.java
@@ -347,7 +347,7 @@ public class GathererController {
                 sbSQL.append("soundtrack BIT,saweternalbond BIT,sightseeing BIT,comm50 BIT,moogleplush BIT,");
                 sbSQL.append("topazcarubuncleplush BIT,emeraldcarbuncleplush BIT,");
                 sbSQL.append("hildibrand BIT, dideternalbond BIT, arrcollector BIT,");
-                sbSQL.append("kobold BIT, sahagin BIT, amaljaa BIT, sylph BIT, moogle BIT, ");
+                sbSQL.append("kobold BIT, sahagin BIT, amaljaa BIT, sylph BIT, moogle BIT, vanuvanu BIT, ");
                 sbSQL.append("arr_25_complete BIT,hw_complete BIT, hw_31_complete BIT, hw_33_complete BIT, legacy_player BIT");
             }
             if (this.storeMounts) {
@@ -509,11 +509,11 @@ public class GathererController {
                                 + player.getBitHasEmeraldCarbunclePlush() + ",");
 
                 sbFields.append("hildibrand, ps4collectors, dideternalbond, arrcollector, kobold, sahagin, amaljaa, "
-                                + "sylph, moogle, hw_complete, hw_31_complete, hw_33_complete, legacy_player");
+                                + "sylph, moogle, vanuvanu, hw_complete, hw_31_complete, hw_33_complete, legacy_player");
                 sbValues.append(player.getBitHasCompletedHildibrand() + "," + player.getBitHasPS4Collectors() + ","
                         + player.getBitHasEternalBond() + "," + player.getBitHasARRCollectors() + ","
                         + player.getBitHasKobold() + "," + player.getBitHasSahagin() + "," + player.getBitHasAmaljaa()
-                        + "," + player.getBitHasSylph() + "," + player.getBitHasMoogle()
+                        + "," + player.getBitHasSylph() + "," + player.getBitHasMoogle() + "," + player.getBitHasVanuVanu()
                         + "," + player.getBitHasCompletedHW() + ","
                         + player.getBitHasCompleted3pt1() + "," + player.getBitHasCompleted3pt3() + ","
                         + player.getBitIsLegacyPlayer());

--- a/src/main/java/com/ffxivcensus/gatherer/GathererController.java
+++ b/src/main/java/com/ffxivcensus/gatherer/GathererController.java
@@ -347,7 +347,7 @@ public class GathererController {
                 sbSQL.append("soundtrack BIT,saweternalbond BIT,sightseeing BIT,comm50 BIT,moogleplush BIT,");
                 sbSQL.append("topazcarubuncleplush BIT,emeraldcarbuncleplush BIT,");
                 sbSQL.append("hildibrand BIT, dideternalbond BIT, arrcollector BIT,");
-                sbSQL.append("kobold BIT, sahagin BIT, amaljaa BIT, sylph BIT,");
+                sbSQL.append("kobold BIT, sahagin BIT, amaljaa BIT, sylph BIT, moogle BIT, ");
                 sbSQL.append("arr_25_complete BIT,hw_complete BIT, hw_31_complete BIT, hw_33_complete BIT, legacy_player BIT");
             }
             if (this.storeMounts) {
@@ -509,11 +509,12 @@ public class GathererController {
                                 + player.getBitHasEmeraldCarbunclePlush() + ",");
 
                 sbFields.append("hildibrand, ps4collectors, dideternalbond, arrcollector, kobold, sahagin, amaljaa, "
-                                + "sylph, hw_complete, hw_31_complete, hw_33_complete, legacy_player");
+                                + "sylph, moogle, hw_complete, hw_31_complete, hw_33_complete, legacy_player");
                 sbValues.append(player.getBitHasCompletedHildibrand() + "," + player.getBitHasPS4Collectors() + ","
                         + player.getBitHasEternalBond() + "," + player.getBitHasARRCollectors() + ","
                         + player.getBitHasKobold() + "," + player.getBitHasSahagin() + "," + player.getBitHasAmaljaa()
-                        + "," + player.getBitHasSylph() + "," + player.getBitHasCompletedHW() + ","
+                        + "," + player.getBitHasSylph() + "," + player.getBitHasMoogle()
+                        + "," + player.getBitHasCompletedHW() + ","
                         + player.getBitHasCompleted3pt1() + "," + player.getBitHasCompleted3pt3() + ","
                         + player.getBitIsLegacyPlayer());
 

--- a/src/main/java/com/ffxivcensus/gatherer/GathererController.java
+++ b/src/main/java/com/ffxivcensus/gatherer/GathererController.java
@@ -342,8 +342,10 @@ public class GathererController {
             if (this.storeProgression) {
                 sbSQL.append(",");
                 sbSQL.append("p30days BIT, p60days BIT, p90days BIT, p180days BIT, p270days BIT,p360days BIT,p450days BIT,p630days BIT,p960days BIT,");
-                sbSQL.append("prearr BIT,prehw BIT, artbook BIT, beforemeteor BIT, beforethefall BIT, ps4collectors BIT, ");
+                sbSQL.append("prearr BIT,prehw BIT, arrartbook BIT, hwartbookone BIT, hwartbooktwo BIT, hasencyclopedia BIT, ");
+                sbSQL.append("beforemeteor BIT, beforethefall BIT, ps4collectors BIT, ");
                 sbSQL.append("soundtrack BIT,saweternalbond BIT,sightseeing BIT,comm50 BIT,moogleplush BIT,");
+                sbSQL.append("topazcarubuncleplush BIT,emeraldcarbuncleplush BIT,");
                 sbSQL.append("hildibrand BIT, dideternalbond BIT, arrcollector BIT,");
                 sbSQL.append("kobold BIT, sahagin BIT, amaljaa BIT, sylph BIT,");
                 sbSQL.append("arr_25_complete BIT,hw_complete BIT, hw_31_complete BIT, hw_33_complete BIT, legacy_player BIT");
@@ -494,14 +496,17 @@ public class GathererController {
                         + player.getBitHas450DaysSub() + "," + player.getBitHas630DaysSub() + ","
                         + player.getBitHas960DaysSub() + ",");
 
-                sbFields.append("prearr, prehw, artbook, beforemeteor, beforethefall, soundtrack, saweternalbond, "
-                                + "sightseeing, arr_25_complete, comm50, moogleplush,");
+                sbFields.append("prearr, prehw, arrartbook, hwartbookone, hwartbooktwo, hasencyclopedia, beforemeteor, beforethefall, soundtrack, saweternalbond, "
+                                + "sightseeing, arr_25_complete, comm50, moogleplush, topazcarubuncleplush, emeraldcarbuncleplush");
                 sbValues.append(player.getBitHasPreOrderArr() + "," + player.getBitHasPreOrderHW() + ","
-                                + player.getBitHasArtBook() + "," + player.getBitHasBeforeMeteor() + ","
+                                + player.getBitHasArrArtbook() + "," + player.getBitHasHWArtbookOne() + ","
+                                + player.getBitHasHWArtbookTwo() + "," + player.getBitHasEncyclopediaEorzea() + ","
+                                + player.getBitHasBeforeMeteor() + ","
                                 + player.getBitHasBeforeTheFall() + "," + player.getBitHasSoundTrack() + ","
                                 + player.getBitHasAttendedEternalBond() + "," + player.getBitHasCompletedHWSightseeing()
                                 + "," + player.getBitHasCompleted2pt5() + "," + player.getBitHasFiftyComms() + ","
-                                + player.getBitHasMooglePlush() + ",");
+                                + player.getBitHasMooglePlush() + "," + player.getBitHasTopazCarbunclePlush() + ","
+                                + player.getBitHasEmeraldCarbunclePlush() + ",");
 
                 sbFields.append("hildibrand, ps4collectors, dideternalbond, arrcollector, kobold, sahagin, amaljaa, "
                                 + "sylph, hw_complete, hw_31_complete, hw_33_complete, legacy_player");

--- a/src/main/java/com/ffxivcensus/gatherer/Player.java
+++ b/src/main/java/com/ffxivcensus/gatherer/Player.java
@@ -81,7 +81,10 @@ public class Player {
     private boolean has960DaysSub;
     private boolean hasPreOrderArr;
     private boolean hasPreOrderHW;
-    private boolean hasArtbook;
+    private boolean hasARRArtbook;
+    private boolean hasHWArtbookOne;
+    private boolean hasHWArtbookTwo;
+    private boolean hasEncyclopediaEorzea;
     private boolean hasBeforeMeteor;
     private boolean hasBeforeTheFall;
     private boolean hasSoundtrack;
@@ -90,6 +93,8 @@ public class Player {
     private boolean hasCompleted2pt5;
     private boolean hasFiftyComms;
     private boolean hasMooglePlush;
+    private boolean hasTopazCarbunclePlush;
+    private boolean hasEmeraldCarbunclePlush;
     private boolean hasCompletedHildibrand;
     private boolean hasPS4Collectors;
     private boolean hasEternalBond;
@@ -154,7 +159,10 @@ public class Player {
         setHas960DaysSub(false);
         setHasPreOrderArr(false);
         setHasPreOrderHW(false);
-        setHasArtbook(false);
+        setHasARRArtbook(false);
+        setHasHWArtbookOne(false);
+        setHasHWArtbookTwo(false);
+        setHasEncyclopediaEorzea(false);
         setHasBeforeMeteor(false);
         setHasBeforeTheFall(false);
         setHasSoundtrack(false);
@@ -163,6 +171,8 @@ public class Player {
         setHasCompleted2pt5(false);
         setHasFiftyComms(false);
         setHasMooglePlush(false);
+        setHasTopazCarbunclePlush(false);
+        setHasEmeraldCarbunclePlush(false);
         setHasCompletedHildibrand(false);
         setHasPS4Collectors(false);
         setHasEternalBond(false);
@@ -1063,8 +1073,8 @@ public class Player {
      *
      * @return whether the user has purchased the artbook.
      */
-    public boolean isHasArtbook() {
-        return hasArtbook;
+    public boolean isHasARRArtbook() {
+        return hasARRArtbook;
     }
 
     /**
@@ -1072,8 +1082,8 @@ public class Player {
      *
      * @return bit value as to whether the player has purchased the artbook.
      */
-    public int getBitHasArtBook() {
-        if (isHasArtbook()) {
+    public int getBitHasArrArtbook() {
+        if (isHasARRArtbook()) {
             return 1;
         } else {
             return 0;
@@ -1083,10 +1093,10 @@ public class Player {
     /**
      * Set whether the player has purchased the artbook.
      *
-     * @param hasArtbook whether the player has purchased the artbook.
+     * @param hasARRArtbook whether the player has purchased the artbook.
      */
-    public void setHasArtbook(boolean hasArtbook) {
-        this.hasArtbook = hasArtbook;
+    public void setHasARRArtbook(boolean hasARRArtbook) {
+        this.hasARRArtbook = hasARRArtbook;
     }
 
     /**
@@ -1875,7 +1885,10 @@ public class Player {
             player.setHas960DaysSub(player.doesPlayerHaveMinion("Wind-up Firion"));
             player.setHasPreOrderArr(player.doesPlayerHaveMinion("Cait Sith Doll"));
             player.setHasPreOrderHW(player.doesPlayerHaveMinion("Chocobo Chick Courier"));
-            player.setHasArtbook(player.doesPlayerHaveMinion("Model Enterprise"));
+            player.setHasARRArtbook(player.doesPlayerHaveMinion("Model Enterprise"));
+            player.setHasHWArtbookOne(player.doesPlayerHaveMinion("Wind-Up Relm"));
+            player.setHasHWArtbookTwo(player.doesPlayerHaveMinion("Wind-Up Hraesvelgr"));
+            player.setHasEncyclopediaEorzea(player.doesPlayerHaveMinion("Namingway"));
             player.setHasBeforeMeteor(player.doesPlayerHaveMinion("Wind-up Dalamud"));
             player.setHasBeforeTheFall(player.doesPlayerHaveMinion("Set Of Primogs"));
             player.setHasSoundtrack(player.doesPlayerHaveMinion("Wind-up Bahamut"));
@@ -1884,6 +1897,8 @@ public class Player {
             player.setHasCompleted2pt5(player.doesPlayerHaveMinion("Midgardsormr"));
             player.setHasFiftyComms(player.doesPlayerHaveMinion("Princely Hatchling"));
             player.setHasMooglePlush(player.doesPlayerHaveMinion("Wind-up Delivery Moogle"));
+            player.setHasTopazCarbunclePlush(player.doesPlayerHaveMinion("Heliodor Carbuncle"));
+            player.setHasEmeraldCarbunclePlush(player.doesPlayerHaveMinion("Peridot Carbuncle"));
             player.setHasCompletedHildibrand(player.doesPlayerHaveMinion("Wind-up Gentleman"));
             player.setHasPS4Collectors(player.doesPlayerHaveMinion("Wind-up Moogle"));
             player.setHasCompleted3pt1(player.doesPlayerHaveMinion("Wind-up Haurchefant"));
@@ -2184,5 +2199,130 @@ public class Player {
      */
     public void setActive(boolean active) {
         isActive = active;
+    }
+
+    /**
+     * Get whether the Player has the Artbook 'Stone and Steel'
+     * @return whether the Player has the Artbook 'Stone and Steel'
+     */
+    public boolean isHasHWArtbookOne() {
+        return hasHWArtbookOne;
+    }
+
+    /**
+     * Get whether the Player has the Artbook 'Stone and Steel'
+     * @return whether the Player has the Artbook 'Stone and Steel'
+     */
+    public int getBitHasHWArtbookOne() {
+        if(this.hasHWArtbookOne) return 1;
+        return 0;
+    }
+
+    /**
+     * Set whether the Player has the Artbook 'Stone and Steel'
+     * @param hasHWArtbookOne whether the Player has the Artbook 'Stone and Steel'
+     */
+    public void setHasHWArtbookOne(boolean hasHWArtbookOne) {
+        this.hasHWArtbookOne = hasHWArtbookOne;
+    }
+
+    /**
+     * Get whether Player has the Artbook 'Scars of War'
+     * @return whether Player has the Artbook 'Scars of War'
+     */
+    public boolean isHasHWArtbookTwo() {
+        return hasHWArtbookTwo;
+    }
+
+    /**
+     * Get whether Player has the Artbook 'Scars of War'
+     * @return whether Player has the Artbook 'Scars of War'
+     */
+    public int getBitHasHWArtbookTwo() {
+        if(this.hasHWArtbookTwo) return 1;
+        return 0;
+    }
+
+    /**
+     * Set whether Player has the Artbook 'Scars of War'
+     * @param hasHWArtbookTwo whether Player has the Artbook 'Scars of War'
+     */
+    public void setHasHWArtbookTwo(boolean hasHWArtbookTwo) {
+        this.hasHWArtbookTwo = hasHWArtbookTwo;
+    }
+
+    /**
+     * Get whether the Player has the FFXIV Lorebook - Encyclopedia Eorzea
+     * @return whether the Player has the FFXIV Lorebook - Encyclopedia Eorzea
+     */
+    public boolean isHasEncyclopediaEorzea() {
+        return hasEncyclopediaEorzea;
+    }
+
+    /**
+     * Get whether the Player has the FFXIV Lorebook - Encyclopedia Eorzea
+     * @return whether the Player has the FFXIV Lorebook - Encyclopedia Eorzea
+     */
+    public int getBitHasEncyclopediaEorzea() {
+        if(this.hasEncyclopediaEorzea) return 1;
+        return 0;
+    }
+
+    /**
+     * Set whether the Player has the FFXIV Lorebook - Encyclopedia Eorzea
+     * @param hasEncyclopediaEorzea whether the Player has the FFXIV Lorebook - Encyclopedia Eorzea
+     */
+    public void setHasEncyclopediaEorzea(boolean hasEncyclopediaEorzea) {
+        this.hasEncyclopediaEorzea = hasEncyclopediaEorzea;
+    }
+
+    /**
+     * Get whether the player has the topaz carbuncle plush
+     * @return whether the player has the topaz carbuncle plush
+     */
+    public boolean isHasTopazCarbunclePlush() {
+        return hasTopazCarbunclePlush;
+    }
+
+    /**
+     * Get whether the player has the topaz carbuncle plush
+     * @return whether the player has the topaz carbuncle plush
+     */
+    public int getBitHasTopazCarbunclePlush() {
+        if(this.hasTopazCarbunclePlush) return 1;
+        return 0;
+    }
+
+    /**
+     * Set whether the player has the topaz carbuncle plush
+     * @param hasTopazCarbunclePlush whether the player has the topaz carbuncle plush
+     */
+    public void setHasTopazCarbunclePlush(boolean hasTopazCarbunclePlush) {
+        this.hasTopazCarbunclePlush = hasTopazCarbunclePlush;
+    }
+
+    /**
+     * Get whether the player has the emerald carbuncle plush
+     * @return whether the player has the emerald carbuncle plush
+     */
+    public boolean isHasEmeraldCarbunclePlush() {
+        return hasEmeraldCarbunclePlush;
+    }
+
+    /**
+     * Get whether the player has the emerald carbuncle plush
+     * @return whether the player has the emerald carbuncle plush
+     */
+    public int getBitHasEmeraldCarbunclePlush() {
+        if(this.hasEmeraldCarbunclePlush) return 1;
+        return 0;
+    }
+
+    /**
+     * Set whether the player has the emerald carbuncle plush
+     * @param hasEmeraldCarbunclePlush whether the player has the emerald carbuncle plush
+     */
+    public void setHasEmeraldCarbunclePlush(boolean hasEmeraldCarbunclePlush) {
+        this.hasEmeraldCarbunclePlush = hasEmeraldCarbunclePlush;
     }
 }

--- a/src/main/java/com/ffxivcensus/gatherer/Player.java
+++ b/src/main/java/com/ffxivcensus/gatherer/Player.java
@@ -104,6 +104,7 @@ public class Player {
     private boolean hasAmaljaa;
     private boolean hasSylph;
     private boolean hasMoogle;
+    private boolean hasVanuVanu;
     private boolean hasCompletedHW;
     private boolean hasCompleted3pt1;
     private boolean hasCompleted3pt3;
@@ -183,6 +184,7 @@ public class Player {
         setHasAmaljaa(false);
         setHasSylph(false);
         setHasMoogle(false);
+        setHasVanuVanu(false);
         setHasCompletedHW(false);
         setHasCompleted3pt1(false);
         setHasCompleted3pt3(false);
@@ -1912,6 +1914,7 @@ public class Player {
             player.setHasAmaljaa(player.doesPlayerHaveMount("Cavalry Drake"));
             player.setHasSylph(player.doesPlayerHaveMount("Laurel Goobbue"));
             player.setHasMoogle(player.doesPlayerHaveMount("Cloud Mallow"));
+            player.setHasVanuVanu(player.doesPlayerHaveMount("Sanuwa"));
             player.setHasCompletedHW(player.doesPlayerHaveMount("Midgardsormr"));
             player.setIsLegacyPlayer(player.doesPlayerHaveMount("Legacy Chocobo"));
             player.setActive(player.isPlayerActiveInDateRange());
@@ -2355,4 +2358,29 @@ public class Player {
         this.hasMoogle = hasMoogle;
     }
 
+    /**
+     * Get whether player has reached Rank 7 with Vanu Vanu Beast Tribe
+     * @return whether player has reached Rank 7 with Vanu Vanu Beast Tribe
+     */
+    public boolean isHasVanuVanu() {
+        return hasVanuVanu;
+    }
+
+    /**
+     * Get whether player has reached Rank 7 with Vanu Vanu Beast Tribe
+     * @return whether player has reached Rank 7 with Vanu Vanu Beast Tribe
+     */
+    public int getBitHasVanuVanu() {
+        if(this.hasVanuVanu) return 1;
+        return 0;
+    }
+
+
+    /**
+     * Set whether player has reached Rank 7 with Vanu Vanu Beast Tribe
+     * @param hasVanuVanu whether player has reached Rank 7 with Vanu Vanu Beast Tribe
+     */
+    public void setHasVanuVanu(boolean hasVanuVanu) {
+        this.hasVanuVanu = hasVanuVanu;
+    }
 }

--- a/src/main/java/com/ffxivcensus/gatherer/Player.java
+++ b/src/main/java/com/ffxivcensus/gatherer/Player.java
@@ -103,6 +103,7 @@ public class Player {
     private boolean hasSahagin;
     private boolean hasAmaljaa;
     private boolean hasSylph;
+    private boolean hasMoogle;
     private boolean hasCompletedHW;
     private boolean hasCompleted3pt1;
     private boolean hasCompleted3pt3;
@@ -181,6 +182,7 @@ public class Player {
         setHasSahagin(false);
         setHasAmaljaa(false);
         setHasSylph(false);
+        setHasMoogle(false);
         setHasCompletedHW(false);
         setHasCompleted3pt1(false);
         setHasCompleted3pt3(false);
@@ -1909,6 +1911,7 @@ public class Player {
             player.setHasSahagin(player.doesPlayerHaveMount("Cavalry Elbst"));
             player.setHasAmaljaa(player.doesPlayerHaveMount("Cavalry Drake"));
             player.setHasSylph(player.doesPlayerHaveMount("Laurel Goobbue"));
+            player.setHasMoogle(player.doesPlayerHaveMount("Cloud Mallow"));
             player.setHasCompletedHW(player.doesPlayerHaveMount("Midgardsormr"));
             player.setIsLegacyPlayer(player.doesPlayerHaveMount("Legacy Chocobo"));
             player.setActive(player.isPlayerActiveInDateRange());
@@ -2325,4 +2328,31 @@ public class Player {
     public void setHasEmeraldCarbunclePlush(boolean hasEmeraldCarbunclePlush) {
         this.hasEmeraldCarbunclePlush = hasEmeraldCarbunclePlush;
     }
+
+    /**
+     * Get whether player has reached Rank 7 with Moogle Beast Tribe
+     * @return whether player has reached Rank 7 with Moogle Beast Tribe
+     */
+    public boolean isHasMoogle() {
+        return hasMoogle;
+    }
+
+    /**
+     * Get whether player has reached Rank 7 with Moogle Beast Tribe
+     * @return whether player has reached Rank 7 with Moogle Beast Tribe
+     */
+    public int getBitHasMoogle() {
+        if(this.hasMoogle) return 1;
+        return 0;
+    }
+
+
+    /**
+     * Set whether player has reached Rank 7 with Moogle Beast Tribe
+     * @param hasMoogle whether player has reached Rank 7 with Moogle Beast Tribe
+     */
+    public void setHasMoogle(boolean hasMoogle) {
+        this.hasMoogle = hasMoogle;
+    }
+
 }

--- a/src/main/java/com/ffxivcensus/gatherer/Player.java
+++ b/src/main/java/com/ffxivcensus/gatherer/Player.java
@@ -840,7 +840,7 @@ public class Player {
      * @return whether the player has had 180 days of subscription time as a bit value.
      */
     public int getBitHas180DaysSub() {
-        if (isHas90DaysSub()) {
+        if (isHas180DaysSub()) {
             return 1;
         } else {
             return 0;

--- a/src/main/java/com/ffxivcensus/gatherer/Player.java
+++ b/src/main/java/com/ffxivcensus/gatherer/Player.java
@@ -1911,14 +1911,9 @@ public class Player {
 
         Calendar date = Calendar.getInstance();
         long t= date.getTimeInMillis();
-        Date nowMinusExcludeRange =new Date(t - (EXCLUDE_RANGE * 30000));
 
         Date nowMinusIncludeRange = new Date(t - (ACTIVITY_RANGE_DAYS * ONE_DAY_IN_MILLIS));
-        if(this.dateImgLastModified.after(nowMinusExcludeRange)) { //If the date modified is inside the exclude range
-            //Reset the last modified date to epoch because we aren't considering it valid
-            this.dateImgLastModified = new Date(0);
-            return false;
-        } else return this.dateImgLastModified.after(nowMinusIncludeRange); //If the date occurs between the include range and now, then return true. Else false
+        return this.dateImgLastModified.after(nowMinusIncludeRange); //If the date occurs between the include range and now, then return true. Else false
     }
 
     /**

--- a/src/main/java/com/ffxivcensus/gatherer/Player.java
+++ b/src/main/java/com/ffxivcensus/gatherer/Player.java
@@ -105,6 +105,7 @@ public class Player {
     private boolean hasSylph;
     private boolean hasMoogle;
     private boolean hasVanuVanu;
+    private boolean hasVath;
     private boolean hasCompletedHW;
     private boolean hasCompleted3pt1;
     private boolean hasCompleted3pt3;
@@ -185,6 +186,7 @@ public class Player {
         setHasSylph(false);
         setHasMoogle(false);
         setHasVanuVanu(false);
+        setHasVath(false);
         setHasCompletedHW(false);
         setHasCompleted3pt1(false);
         setHasCompleted3pt3(false);
@@ -1915,6 +1917,7 @@ public class Player {
             player.setHasSylph(player.doesPlayerHaveMount("Laurel Goobbue"));
             player.setHasMoogle(player.doesPlayerHaveMount("Cloud Mallow"));
             player.setHasVanuVanu(player.doesPlayerHaveMount("Sanuwa"));
+            player.setHasVath(player.doesPlayerHaveMount("Kongamato"));
             player.setHasCompletedHW(player.doesPlayerHaveMount("Midgardsormr"));
             player.setIsLegacyPlayer(player.doesPlayerHaveMount("Legacy Chocobo"));
             player.setActive(player.isPlayerActiveInDateRange());
@@ -2382,5 +2385,30 @@ public class Player {
      */
     public void setHasVanuVanu(boolean hasVanuVanu) {
         this.hasVanuVanu = hasVanuVanu;
+    }
+
+    /**
+     * Get whether player has reached Rank 7 with Vath Beast Tribe
+     * @return whether player has reached Rank 7 with Vath Tribe
+     */
+    public boolean isHasVath() {
+        return hasVath;
+    }
+
+    /**
+     * Get whether player has reached Rank 7 with Vath Beast Tribe
+     * @return whether player has reached Rank 7 with Vath Beast Tribe
+     */
+    public int getBitHasVath() {
+        if(this.hasVath) return 1;
+        return 0;
+    }
+
+    /**
+     * Set whether player has reached Rank 7 with Vath Beast Tribe
+     * @param hasVath whether player has reached Rank 7 with Vath Beast Tribe
+     */
+    public void setHasVath(boolean hasVath) {
+        this.hasVath = hasVath;
     }
 }

--- a/src/test/java/com/ffxivcensus/gatherer/PlayerTest.java
+++ b/src/test/java/com/ffxivcensus/gatherer/PlayerTest.java
@@ -1,7 +1,5 @@
 package com.ffxivcensus.gatherer;
 
-import com.ffxivcensus.gatherer.Player;
-
 import java.util.Date;
 
 import static org.junit.Assert.*;
@@ -102,8 +100,8 @@ public class PlayerTest {
         assertTrue(playerOne.isHasARRCollectors());
         assertEquals(playerOne.getBitHasARRCollectors(), 1);
         //Assuming the below don't change
-        assertFalse(playerOne.isHasArtbook());
-        assertEquals(playerOne.getBitHasArtBook(), 0);
+        assertFalse(playerOne.isHasARRArtbook());
+        assertEquals(playerOne.getBitHasArrArtbook(), 0);
         assertFalse(playerOne.isHasBeforeMeteor());
         assertEquals(playerOne.getBitHasBeforeMeteor(), 0);
         assertFalse(playerOne.isHasBeforeTheFall());
@@ -274,7 +272,7 @@ public class PlayerTest {
     public void testGetPlayerWithAllCollectibles() throws Exception {
         Player player = Player.getPlayer(71);
 
-        assertEquals(player.getBitHasArtBook(), 1);
+        assertEquals(player.getBitHasArrArtbook(), 1);
         assertEquals(player.getBitHasBeforeMeteor(), 1);
         assertEquals(player.getBitHasBeforeTheFall(), 1);
         assertEquals(player.getBitHasSoundTrack(), 1);


### PR DESCRIPTION
# References Issues

## Resolves

- XIVStats/XIVStats#5 -Add merchandise

## Affects

- XIVStats/XIVStats#1 -Add better means of determining activity

# Changelog

## Bugfixes
* Completely removed 30 second exclude range from image reader - it was excluding players that are active, and none of the players being excluded are inactive.

## Compatibility breaking changes
* DB field `artbook` renamed to `arrartbook`

## Added Achievements
* Added parsing for owners of Encyclopedia Eorzea (Minion: `Namingway`)
* Added parsing for owners of Heavensward Lore book 1 (Minion: `Wind-Up Relm`)
* Added parsing for owners of Heavensward Lore book 2 (Minion: `Wind-Up Hraesvelgr`)
* Added parsing for owners of Topaz Carbuncle plush (Minion: `Heliodor Carbuncle`)
* Added parsing for owners of Emerald Carbuncle plush (Minion: `Peridot Carbuncle`)
* Added parsing for characters who have completed Moogle Beast Tribe to Rank 7 (Mount: `Cloud Mallow`)
* Added parsing for characters who have completed Vanu Vanu Beast Tribe to Rank 7 (Mount: `Sanuwa`)
* Added parsing for characters who have completed Vath Beast Tribe to Rank 7 (Mount: `Kongamato`)
* [Bugfix] 180 days and 90 day subscriptions were returning wrong value