### PR TITLE
Remove un-necessary print statement

### DIFF
--- a/src/main/java/com/ffxivcensus/gatherer/Player.java
+++ b/src/main/java/com/ffxivcensus/gatherer/Player.java
@@ -2082,7 +2082,6 @@ public class Player {
                     levels.add(Integer.parseInt(strLvl));
                 }
             }
-            System.out.print(levelBoxes.size());
         }
 
         //Initialize int array

--- a/src/test/java/com/ffxivcensus/gatherer/PlayerTest.java
+++ b/src/test/java/com/ffxivcensus/gatherer/PlayerTest.java
@@ -226,7 +226,6 @@ public class PlayerTest {
         assertEquals(player.getBitHasARRCollectors(), 0);
         //Tricky to test this - testing here that it was at the very least set to some value other than what it is set to a value other than that which it is initialized
         assertTrue(player.getDateImgLastModified() != new Date());
-        assertFalse(player.isActive());
 
         //Test get minions method
         assertTrue(player.getMinions().size() == 0);


### PR DESCRIPTION
Found the potential cause of the integer being printed before lines on console output