### PR TITLE
Fix for Null Pointer issue on boot

### DIFF
--- a/src/main/java/com/ffxivcensus/gatherer/GathererController.java
+++ b/src/main/java/com/ffxivcensus/gatherer/GathererController.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import com.ffxivcensus.gatherer.config.ApplicationConfig;
 import com.ffxivcensus.gatherer.player.CharacterStatus;
+import com.ffxivcensus.gatherer.player.PlayerBean;
 import com.ffxivcensus.gatherer.player.PlayerBeanRepository;
 import com.ffxivcensus.gatherer.player.PlayerBuilder;
 
@@ -119,8 +120,9 @@ public class GathererController {
     private void gatherRange() {
         // Firstly, clean the top-end of the database
         LOG.debug("Cleaning top-end characters from the database");
-        playerRepository.deleteByIdGreaterThan(playerRepository.findTopByIdByCharacterStatusNotDeleted());
-
+        Integer highestValid = playerRepository.findTopByIdByCharacterStatusNotDeleted();
+        // Delete everything higher than last known good player
+        playerRepository.deleteByIdGreaterThan(highestValid != null ? highestValid.intValue() : 0);
         // Set next ID
         int nextID = appConfig.getStartId();
 


### PR DESCRIPTION
@Pricetx / @ReidWeb - This fixes the boot issues you've had on a freshly created/upgraded DB where a potential Null return from the DB causes the gathering to die.

The fix affects `master` and is a backport of a fix I'd already done in the `unattended_gathering` (#30) branch, but hadn't put 2-and-2 together.