### PR TITLE
Increase GATHERING_VALID_GAP_MAX to 50000

### DIFF
--- a/src/main/java/com/ffxivcensus/gatherer/task/GatheringLimiterTask.java
+++ b/src/main/java/com/ffxivcensus/gatherer/task/GatheringLimiterTask.java
@@ -18,7 +18,7 @@ public class GatheringLimiterTask implements Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(GatheringLimiterTask.class);
     /** Defines the maximum number of ID's between the highest ID number and the last known good Character. **/
-    private static final int GATHERING_VALID_GAP_MAX = 5000;
+    private static final int GATHERING_VALID_GAP_MAX = 50000;
 
     private ThreadPoolExecutor gathererExecutor;
     private PlayerBeanRepository characterRepository;

--- a/src/test/java/com/ffxivcensus/gatherer/task/GatheringLimiterTaskTest.java
+++ b/src/test/java/com/ffxivcensus/gatherer/task/GatheringLimiterTaskTest.java
@@ -63,7 +63,7 @@ public class GatheringLimiterTaskTest {
     @Test
     public void testContinueAtMarginCondition() {
         PlayerBean topId = new PlayerBean();
-        topId.setId(5100);
+        topId.setId(50100);
         PlayerBean topValid = new PlayerBean();
         topValid.setId(100);
         
@@ -78,7 +78,7 @@ public class GatheringLimiterTaskTest {
     @Test
     public void testStopCondition() {
         PlayerBean topId = new PlayerBean();
-        topId.setId(5101);
+        topId.setId(50101);
         PlayerBean topValid = new PlayerBean();
         topValid.setId(100);
         


### PR DESCRIPTION
GATHERING_VALID_GAP_MAX is still causing the run to terminate at around ID 2,000,000 when set to 5,000. Increasing to 50,000 to get a run completed. After a completed run we can work out what a sensible value would be.