### PR TITLE
#39 Auto-Stop Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Follow these steps to setup XIVStats-Gatherer-Java:
   |:------------:|:---------------------:|:--------------:|:--------------------------------------------------------------------:|
   |-d            | --database            | String         | database name                                                        |
   |-f            | --finish              | integer        | the character id to conclude character run at (inclusive)            |
+  |-a			 | --autostopfrom        | integer        | the lowest character id to allow auto-stop to happen                 |
+  |-g			 | --autostopgap         | integer        | the number of continuous invalid characters to trigger auto-stopping |
   |-h            | --help                | none           | display help message                                                 |
   |-p            | --password            | String         | database user password                                               |
   |-s            | --start               | integer        | the character id to start from (inclusive)                           |

--- a/config_example.xml
+++ b/config_example.xml
@@ -8,5 +8,6 @@
     </jdbc>
     <execution>
         <threads>32</threads>
+        <autoStopLowerLimit>10000000</autoStopLowerLimit>
     </execution>
 </config>

--- a/src/main/java/com/ffxivcensus/gatherer/CLIConstants.java
+++ b/src/main/java/com/ffxivcensus/gatherer/CLIConstants.java
@@ -9,7 +9,7 @@ import org.apache.commons.cli.Options;
  * @author matthew.hillier
  */
 public class CLIConstants {
-    public static final String CLI_USAGE = "java -jar XIVStats-Gatherer-Java.jar [-i] -s startid [-f finishid] [-d database-name] [-u database-user] [-p database-user-password] [-U database-url] [-t threads]";
+    public static final String CLI_USAGE = "java -jar XIVStats-Gatherer-Java.jar [-i] -s startid [-f finishid] [-a autostop-id] [-g autostop-gap] [-d database-name] [-u database-user] [-p database-user-password] [-U database-url] [-t threads]";
 
     /**
      * Private constructor as this should never me initiated.
@@ -31,6 +31,10 @@ public class CLIConstants {
                                 .desc("the character id to start gatherer run from (inclusive)").required().build();
         Option optFinish = Option.builder("f").longOpt("finish").argName("end-id").hasArg().numberOfArgs(1)
                                  .desc("the character id to conclude gather run at (inclusive)").build();
+        Option optAutoStopLimit = Option.builder("a").longOpt("autostopfrom").argName("autostop-from").hasArg().numberOfArgs(1)
+                                        .desc("the lowest character id to allow auto-stop to happen").build();
+        Option optAutoStopGap = Option.builder("g").longOpt("autostopgap").argName("autostop-gap").hasArg().numberOfArgs(1)
+                                       .desc("the number of continuous invalid characters to trigger auto-stopping").build();
         Option optHelp = Option.builder("h").longOpt("help").desc("display this help message").build();
         Option optURL = Option.builder("U").longOpt("url").argName("database-server-url").hasArg().numberOfArgs(1)
                               .desc("the database url of the database server to connect to e.g. mysql://localhost:3306").build();
@@ -48,6 +52,8 @@ public class CLIConstants {
         // Add each option to the options object
         options.addOption(optStart);
         options.addOption(optFinish);
+        options.addOption(optAutoStopLimit);
+        options.addOption(optAutoStopGap);
         options.addOption(optDB);
         options.addOption(optUser);
         options.addOption(optPassword);

--- a/src/main/java/com/ffxivcensus/gatherer/GathererController.java
+++ b/src/main/java/com/ffxivcensus/gatherer/GathererController.java
@@ -54,8 +54,8 @@ public class GathererController {
 
     /**
      * Start the gatherer controller instance up.
-     * @throws ParseException 
-     *
+     * 
+     * @throws ParseException
      * @throws Exception Exception thrown if system is incorrectly configured.
      */
     public void run() throws ParseException {
@@ -143,7 +143,8 @@ public class GathererController {
                                                5,
                                                TimeUnit.SECONDS);
         // Executes the limiter tasks once every 30 seconds, starting in 30 seconds time.
-        managementExecutor.scheduleAtFixedRate(new GatheringLimiterTask(gathererExecutor,
+        managementExecutor.scheduleAtFixedRate(new GatheringLimiterTask(appConfig,
+                                                                        gathererExecutor,
                                                                         playerRepository),
                                                30,
                                                30,

--- a/src/main/java/com/ffxivcensus/gatherer/config/ApplicationConfig.java
+++ b/src/main/java/com/ffxivcensus/gatherer/config/ApplicationConfig.java
@@ -75,6 +75,16 @@ public class ApplicationConfig {
      */
     private int endId = Integer.MAX_VALUE;
 
+    /**
+     * The lowest character ID to allow auto-stopping to begin at.
+     */
+    private int autoStopLowerLimitId = 0;
+
+    /**
+     * The largest continuous character gap to trigger auto-stopping.
+     */
+    private int autoStopGap = 50000;
+
     /////////////////////////////////
     // Database Configuration Methods
     /////////////////////////////////
@@ -149,5 +159,21 @@ public class ApplicationConfig {
 
     public void setEndId(int endId) {
         this.endId = endId;
+    }
+
+    public int getAutoStopLowerLimitId() {
+        return autoStopLowerLimitId;
+    }
+
+    public void setAutoStopLowerLimitId(int autoStopLowerLimitId) {
+        this.autoStopLowerLimitId = autoStopLowerLimitId;
+    }
+
+    public int getAutoStopGap() {
+        return autoStopGap;
+    }
+
+    public void setAutoStopGap(int autoStopGap) {
+        this.autoStopGap = autoStopGap;
     }
 }

--- a/src/main/java/com/ffxivcensus/gatherer/config/ApplicationConfig.java
+++ b/src/main/java/com/ffxivcensus/gatherer/config/ApplicationConfig.java
@@ -22,6 +22,7 @@ public class ApplicationConfig {
     public static final String DEFAULT_DATABASE_HOST = "mysql://localhost:3306";
     public static final String DEFAULT_DATABASE_NAME = "dbplayers";
     public static final String DEFAULT_TABLE_NAME = "tblplayers";
+    public static final int DEFAULT_AUTOSTOP_GAP = 50000;
 
     /**
      * Safety limit for thread count - user cannot exceed this limit.
@@ -83,7 +84,7 @@ public class ApplicationConfig {
     /**
      * The largest continuous character gap to trigger auto-stopping.
      */
-    private int autoStopGap = 50000;
+    private int autoStopGap = DEFAULT_AUTOSTOP_GAP;
 
     /////////////////////////////////
     // Database Configuration Methods

--- a/src/main/java/com/ffxivcensus/gatherer/config/ConfigurationBuilder.java
+++ b/src/main/java/com/ffxivcensus/gatherer/config/ConfigurationBuilder.java
@@ -150,7 +150,7 @@ public class ConfigurationBuilder {
             
             // Autostop Character Gap Count
             if(cmd.hasOption("g")) {
-                configuration.setAutoStopLowerLimitId(Integer.parseInt(cmd.getOptionValue("g")));
+                configuration.setAutoStopGap(Integer.parseInt(cmd.getOptionValue("g")));
             }
 
             // Database URL

--- a/src/main/java/com/ffxivcensus/gatherer/config/ConfigurationBuilder.java
+++ b/src/main/java/com/ffxivcensus/gatherer/config/ConfigurationBuilder.java
@@ -111,6 +111,10 @@ public class ConfigurationBuilder {
             NodeList nodesExecConf = doc.getElementsByTagName("execution");
             Element elementExecConf = (Element) nodesExecConf.item(0);
             configuration.setThreadLimit(Integer.parseInt(elementExecConf.getElementsByTagName("threads").item(0).getTextContent()));
+            if(elementExecConf.getElementsByTagName("autoStopLowerLimit").getLength() > 0) {
+                configuration.setAutoStopLowerLimitId(Integer.parseInt(elementExecConf.getElementsByTagName("autoStopLowerLimit").item(0)
+                                                                                      .getTextContent()));
+            }
         } else {
             LOG.error("Configuration: No config.xml file found. Failing over to defaults.");
         }
@@ -137,6 +141,16 @@ public class ConfigurationBuilder {
             // Finish id flag
             if(cmd.hasOption("f")) {
                 configuration.setEndId(Integer.parseInt(cmd.getOptionValue("f")));
+            }
+            
+            // Autostop Lower Id
+            if(cmd.hasOption("a")) {
+                configuration.setAutoStopLowerLimitId(Integer.parseInt(cmd.getOptionValue("a")));
+            }
+            
+            // Autostop Character Gap Count
+            if(cmd.hasOption("g")) {
+                configuration.setAutoStopLowerLimitId(Integer.parseInt(cmd.getOptionValue("g")));
             }
 
             // Database URL

--- a/src/test/java/com/ffxivcensus/gatherer/config/ConfigurationBuilderTest.java
+++ b/src/test/java/com/ffxivcensus/gatherer/config/ConfigurationBuilderTest.java
@@ -28,6 +28,7 @@ public class ConfigurationBuilderTest {
         assertEquals(Integer.MAX_VALUE, config.getEndId());
         assertEquals(ApplicationConfig.MAX_THREADS, config.getThreadLimit());
         assertEquals(ApplicationConfig.DEFAULT_DATABASE_HOST, config.getDbUrl());
+        assertEquals(ApplicationConfig.DEFAULT_AUTOSTOP_GAP, config.getAutoStopGap());
     }
 
     /**
@@ -46,6 +47,7 @@ public class ConfigurationBuilderTest {
         assertEquals(Integer.MAX_VALUE, config.getEndId());
         assertEquals("mysql://testbox:3306", config.getDbUrl());
         assertEquals(32, config.getThreadLimit());
+        assertEquals(10000000, config.getAutoStopLowerLimitId());
     }
 
     /**
@@ -93,6 +95,7 @@ public class ConfigurationBuilderTest {
     public void testValidCLIConfigPartial() throws Exception {
         String[] args = {"-is", "0",
                          "-f", "100",
+                         "-g", "56",
                          "-t", "10",
                          "-d", "DatabaseName",
                          "-U", "jdbc:mysql://test-server"};
@@ -105,6 +108,7 @@ public class ConfigurationBuilderTest {
         assertEquals(0, config.getStartId());
         assertEquals(100, config.getEndId());
         assertEquals(10, config.getThreadLimit());
+        assertEquals(56, config.getAutoStopGap());
     }
 
     /**
@@ -127,7 +131,9 @@ public class ConfigurationBuilderTest {
                          "-d", "DatabaseName",
                          "-U", "jdbc:mysql://test-server",
                          "-u", "user",
-                         "-p", "password"};
+                         "-p", "password",
+                         "-a", "56000",
+                         "-g", "150"};
 
         ApplicationConfig config = ConfigurationBuilder.createBuilder()
                                                        .loadCommandLineConfiguration(CLIConstants.setupOptions(), args)
@@ -140,6 +146,8 @@ public class ConfigurationBuilderTest {
         assertEquals("jdbc:mysql://test-server", config.getDbUrl());
         assertEquals("user", config.getDbUser());
         assertEquals("password", config.getDbPassword());
+        assertEquals(56000, config.getAutoStopLowerLimitId());
+        assertEquals(150, config.getAutoStopGap());
     }
 
     @Test(expected = MissingOptionException.class)

--- a/src/test/java/com/ffxivcensus/gatherer/task/GatheringLimiterTaskTest.java
+++ b/src/test/java/com/ffxivcensus/gatherer/task/GatheringLimiterTaskTest.java
@@ -12,6 +12,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+
+import com.ffxivcensus.gatherer.config.ApplicationConfig;
 import com.ffxivcensus.gatherer.player.CharacterStatus;
 import com.ffxivcensus.gatherer.player.PlayerBean;
 import com.ffxivcensus.gatherer.player.PlayerBeanRepository;
@@ -22,12 +24,14 @@ public class GatheringLimiterTaskTest {
     private ThreadPoolExecutor mockExecutor;
     @Mock
     private PlayerBeanRepository mockRepository;
+    private ApplicationConfig config;
     private GatheringLimiterTask instance;
 
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
-        instance = new GatheringLimiterTask(mockExecutor, mockRepository);
+        config = new ApplicationConfig();
+        instance = new GatheringLimiterTask(config, mockExecutor, mockRepository);
     }
     
     @After

--- a/src/test/java/com/ffxivcensus/gatherer/task/GatheringLimiterTaskTest.java
+++ b/src/test/java/com/ffxivcensus/gatherer/task/GatheringLimiterTaskTest.java
@@ -80,6 +80,23 @@ public class GatheringLimiterTaskTest {
     }
     
     @Test
+    public void testContinueWithUnbreachedAutostopLimit() {
+        PlayerBean topId = new PlayerBean();
+        topId.setId(60000);
+        PlayerBean topValid = new PlayerBean();
+        topValid.setId(100);
+        
+        config.setAutoStopLowerLimitId(61000);
+        
+        when(mockRepository.findTopByOrderByIdDesc()).thenReturn(topId);
+        when(mockRepository.findTopByCharacterStatusNotOrderByIdDesc(Mockito.any(CharacterStatus.class))).thenReturn(topValid);
+        
+        instance.run();
+        
+        verify(mockExecutor, never()).shutdownNow();
+    }
+    
+    @Test
     public void testStopCondition() {
         PlayerBean topId = new PlayerBean();
         topId.setId(50101);

--- a/src/test/resources/config/test_config.xml
+++ b/src/test/resources/config/test_config.xml
@@ -8,5 +8,6 @@
     </jdbc>
     <execution>
         <threads>32</threads>
+        <autoStopLowerLimit>10000000</autoStopLowerLimit>
     </execution>
 </config>


### PR DESCRIPTION
Configuration for the auto-stop behaviours we're struggling with in production - Issue #39 :
1. Command-Line only configuration for overriding the character gap size (``-g``)
2. Config file & command-line option for the "lowest" character ID to start looking to auto-stop (defaulted to 10M in supplied demo config file)