### PR TITLE
fix(player): fix bug where characters with no mounts or no minions were being marked as deleted

### DIFF
--- a/src/main/java/com/ffxivcensus/gatherer/lodestone/FetchYieldedPageNotFoundException.java
+++ b/src/main/java/com/ffxivcensus/gatherer/lodestone/FetchYieldedPageNotFoundException.java
@@ -2,10 +2,10 @@ package com.ffxivcensus.gatherer.lodestone;
 
 /**
  * Exeption that identifies that a Character profile has been deleted and is no-longer available on the Lodestone.
- * 
+ *
  * @author matthew.hillier
  */
-public class CharacterDeletedException extends Exception {
+public class FetchYieldedPageNotFoundException extends Exception {
 
     private static final long serialVersionUID = -8280885017582345967L;
 

--- a/src/main/java/com/ffxivcensus/gatherer/lodestone/LodestonePageLoader.java
+++ b/src/main/java/com/ffxivcensus/gatherer/lodestone/LodestonePageLoader.java
@@ -1,13 +1,13 @@
 package com.ffxivcensus.gatherer.lodestone;
 
-import java.io.IOException;
-
 import org.jsoup.nodes.Document;
+
+import java.io.IOException;
 
 /**
  * Interface describing a loader class that can produce {@link Document} objects from a given source.
  * Implementations of this interface should all focus on from a specific source, for example the live loadestone.
- * 
+ *
  * @author matthew.hillier
  */
 public interface LodestonePageLoader {
@@ -18,42 +18,42 @@ public interface LodestonePageLoader {
      * @return
      * @throws IOException
      * @throws InterruptedException
-     * @throws CharacterDeletedException
+     * @throws FetchYieldedPageNotFoundException
      */
-    Document getCharacterPage(final int characterId) throws IOException, InterruptedException, CharacterDeletedException;
-    
+    Document getCharacterPage(final int characterId) throws IOException, InterruptedException, FetchYieldedPageNotFoundException;
+
     /**
      * Fetches a Character's Class & Job info, where available.
      * @param characterId
      * @return
      * @throws IOException
      * @throws InterruptedException
-     * @throws CharacterDeletedException
+     * @throws FetchYieldedPageNotFoundException
      */
-    Document getClassJobPage(final int characterId) throws IOException, InterruptedException, CharacterDeletedException;
-    
+    Document getClassJobPage(final int characterId) throws IOException, InterruptedException, FetchYieldedPageNotFoundException;
+
     /**
      * Fetches a Characters Minions page, where available.
      * @param characterId
      * @return
      * @throws IOException
      * @throws InterruptedException
-     * @throws CharacterDeletedException
+     * @throws FetchYieldedPageNotFoundException
      */
-    Document getMinionPage(final int characterId) throws IOException, InterruptedException, CharacterDeletedException;
-    
+    Document getMinionPage(final int characterId) throws IOException, InterruptedException, FetchYieldedPageNotFoundException;
+
     /**
      * Fetches a Characters Mounts page, where available.
      * @param characterId
      * @return
      * @throws IOException
      * @throws InterruptedException
-     * @throws CharacterDeletedException
+     * @throws FetchYieldedPageNotFoundException
      */
-    Document getMountPage(final int characterId) throws IOException, InterruptedException, CharacterDeletedException;
-    
+    Document getMountPage(final int characterId) throws IOException, InterruptedException, FetchYieldedPageNotFoundException;
+
     /**
-     * Fetches a tooltop page from a 'data-tooltip_href' reference 
+     * Fetches a tooltop page from a 'data-tooltip_href' reference
      * @param href Value from the data-tooltip_href value
      * @return
      * @throws IOException

--- a/src/main/java/com/ffxivcensus/gatherer/lodestone/ProductionLodestonePageLoader.java
+++ b/src/main/java/com/ffxivcensus/gatherer/lodestone/ProductionLodestonePageLoader.java
@@ -1,9 +1,5 @@
 package com.ffxivcensus.gatherer.lodestone;
 
-import java.io.IOException;
-import java.util.Random;
-import java.util.concurrent.TimeUnit;
-
 import org.apache.http.HttpStatus;
 import org.jsoup.HttpStatusException;
 import org.jsoup.Jsoup;
@@ -11,9 +7,13 @@ import org.jsoup.nodes.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
 /**
  * Loadestone Page Loader that works with the live EU lodestone,
- * 
+ *
  * @author matthew.hillier
  */
 public class ProductionLodestonePageLoader implements LodestonePageLoader {
@@ -36,30 +36,30 @@ public class ProductionLodestonePageLoader implements LodestonePageLoader {
 
     /**
      * Fetches the given Character {@link Document} from the Lodestone.
-     * 
+     *
      * @param characterId
      * @return A Jsoup Document object of the page.
      * @throws IOException
      * @throws InterruptedException
-     * @throws CharacterDeletedException When the server returns a 404 response, a CharacterDeletedException will be thrown by this method.
+     * @throws FetchYieldedPageNotFoundException When the server returns a 404 response, a CharacterDeletedException will be thrown by this method.
      */
     @Override
-    public Document getCharacterPage(final int characterId) throws IOException, InterruptedException, CharacterDeletedException {
+    public Document getCharacterPage(final int characterId) throws IOException, InterruptedException, FetchYieldedPageNotFoundException {
         return getPage(baseUrl, characterId, 1);
     }
 
     @Override
-    public Document getClassJobPage(int characterId) throws IOException, InterruptedException, CharacterDeletedException {
+    public Document getClassJobPage(int characterId) throws IOException, InterruptedException, FetchYieldedPageNotFoundException {
         return getPage(baseUrl + SECTION_CLASS_JOB, characterId, 1);
     }
-    
+
     @Override
-    public Document getMinionPage(int characterId) throws IOException, InterruptedException, CharacterDeletedException {
+    public Document getMinionPage(int characterId) throws IOException, InterruptedException, FetchYieldedPageNotFoundException {
         return getPage(baseUrl + SECTION_MINIONS, characterId, 1);
     }
 
     @Override
-    public Document getMountPage(int characterId) throws IOException, InterruptedException, CharacterDeletedException {
+    public Document getMountPage(int characterId) throws IOException, InterruptedException, FetchYieldedPageNotFoundException {
         return getPage(baseUrl + SECTION_MOUNTS, characterId, 1);
     }
 
@@ -86,7 +86,7 @@ public class ProductionLodestonePageLoader implements LodestonePageLoader {
     }
 
     private Document getPage(final String pageUrl, final int characterId, final int attempt) throws IOException, InterruptedException,
-                                                                                             CharacterDeletedException {
+			FetchYieldedPageNotFoundException {
         Document doc;
 
         String url = String.format(pageUrl, characterId);
@@ -108,7 +108,7 @@ public class ProductionLodestonePageLoader implements LodestonePageLoader {
                     break;
                 case HttpStatus.SC_NOT_FOUND:
                     LOG.info("Character {} does not exist. (404)", characterId);
-                    throw new CharacterDeletedException();
+                    throw new FetchYieldedPageNotFoundException();
                 default:
                     throw new IOException("Unexpected HTTP Status Code: " + httpe.getStatusCode(), httpe);
             }

--- a/src/main/java/com/ffxivcensus/gatherer/lodestone/ProductionLodestonePageLoader.java
+++ b/src/main/java/com/ffxivcensus/gatherer/lodestone/ProductionLodestonePageLoader.java
@@ -107,7 +107,7 @@ public class ProductionLodestonePageLoader implements LodestonePageLoader {
                     doc = getPage(url, characterId, attempt);
                     break;
                 case HttpStatus.SC_NOT_FOUND:
-                    LOG.info("Character {} does not exist. (404)", characterId);
+                    LOG.info("Encountered 404 while loading url: {}", url);
                     throw new FetchYieldedPageNotFoundException();
                 default:
                     throw new IOException("Unexpected HTTP Status Code: " + httpe.getStatusCode(), httpe);

--- a/src/test/java/com/ffxivcensus/gatherer/lodestone/TestDataLodestonePageLoader.java
+++ b/src/test/java/com/ffxivcensus/gatherer/lodestone/TestDataLodestonePageLoader.java
@@ -1,14 +1,15 @@
 package com.ffxivcensus.gatherer.lodestone;
 
-import java.io.File;
-import java.io.IOException;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
+
+import java.io.File;
+import java.io.IOException;
 
 public class TestDataLodestonePageLoader implements LodestonePageLoader {
 
     @Override
-    public Document getCharacterPage(int characterId) throws IOException, InterruptedException, CharacterDeletedException {
+    public Document getCharacterPage(int characterId) throws IOException, InterruptedException, FetchYieldedPageNotFoundException {
         Document doc;
         try {
             doc = Jsoup.parse(
@@ -22,9 +23,9 @@ public class TestDataLodestonePageLoader implements LodestonePageLoader {
         }
         return doc;
     }
-    
+
     @Override
-    public Document getClassJobPage(int characterId) throws IOException, InterruptedException, CharacterDeletedException {
+    public Document getClassJobPage(int characterId) throws IOException, InterruptedException, FetchYieldedPageNotFoundException {
         Document doc;
         try {
             doc = Jsoup.parse(
@@ -40,7 +41,7 @@ public class TestDataLodestonePageLoader implements LodestonePageLoader {
     }
 
     @Override
-    public Document getMinionPage(int characterId) throws IOException, InterruptedException, CharacterDeletedException {
+    public Document getMinionPage(int characterId) throws IOException, InterruptedException, FetchYieldedPageNotFoundException {
         Document doc;
         try {
             doc = Jsoup.parse(
@@ -56,7 +57,7 @@ public class TestDataLodestonePageLoader implements LodestonePageLoader {
     }
 
     @Override
-    public Document getMountPage(int characterId) throws IOException, InterruptedException, CharacterDeletedException {
+    public Document getMountPage(int characterId) throws IOException, InterruptedException, FetchYieldedPageNotFoundException {
         Document doc;
         try {
             doc = Jsoup.parse(

--- a/src/test/java/com/ffxivcensus/gatherer/player/PlayerBuilderIT.java
+++ b/src/test/java/com/ffxivcensus/gatherer/player/PlayerBuilderIT.java
@@ -1,19 +1,11 @@
 package com.ffxivcensus.gatherer.player;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import com.ffxivcensus.gatherer.edb.EorzeaDatabaseCache;
+import org.junit.*;
+
 import java.util.Date;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import com.ffxivcensus.gatherer.edb.EorzeaDatabaseCache;
-import com.ffxivcensus.gatherer.player.PlayerBean;
-import com.ffxivcensus.gatherer.player.PlayerBuilder;
+import static org.junit.Assert.*;
 
 /**
  * JUnit test class to test the methods of the Player class.
@@ -116,10 +108,10 @@ public class PlayerBuilderIT {
         assertTrue(playerOne.getLevelMiner() >= 80);
         assertTrue(playerOne.getLevelBotanist() >= 80);
         assertTrue(playerOne.getLevelFisher() >= 80);
-        
+
         // Bozjan Southern Front
         assertTrue(playerOne.getLevelBozja() >= 13);
-        
+
         // The Forbidden Land, Eureka
         assertTrue(playerOne.getLevelEureka() >= 60);
 
@@ -302,11 +294,11 @@ public class PlayerBuilderIT {
         assertTrue(player.isHasCompletedHWSightseeing());
         assertTrue(player.isHasMooglePlush());
     }
-    
+
     @Test
     public void testGetPlayerWithEureka() throws Exception {
         PlayerBean player = instance.getPlayer(2256025);
-        
+
         assertTrue(player.getLevelEureka() > 50);
     }
 
@@ -323,5 +315,37 @@ public class PlayerBuilderIT {
 
         }
     }
+
+	/**
+	 * Perform a test of the getPlayer method, using character #33000008, which has no minions or mounts
+	 */
+	@Test
+	public void testGetPlayerWithNoMinionsNoMounts() {
+		try {
+			// Try to get a character that doesn't exist
+			PlayerBean player = instance.getPlayer(33000008);
+			assertNotEquals("Character should NOT be marked as DELETED", CharacterStatus.DELETED, player.getCharacterStatus());
+			assertEquals("Character should have mount array of length 0", 0, player.getMounts().size());
+			assertEquals("Character should have minion array of length 0", 0, player.getMinions().size());
+		} catch(Exception e) {
+
+		}
+	}
+
+	/**
+	 * Perform a test of the getPlayer method, using character #33000046, which has minions but has no mounts
+	 */
+	@Test
+	public void testGetPlayerWithMinionsButNoMounts() {
+		try {
+			// Try to get a character that doesn't exist
+			PlayerBean player = instance.getPlayer(33000046);
+			assertNotEquals("Character should NOT be marked as deleted", CharacterStatus.DELETED, player.getCharacterStatus());
+			assertTrue("Character should have minion array of length > 0", player.getMinions().size() > 0);
+			assertEquals("Character should have mount array of length 0", 0, player.getMounts().size());
+		} catch(Exception e) {
+
+		}
+	}
 
 }


### PR DESCRIPTION
A CharacterDeletedException was being thrown by `getPage` and not handled for the mount/minion scenario. The general catch statement was handling this as if the whole character was deleted.

To account for this I have also renamed CharacterDeletedException.

Tests have been added to the integration test suite to confirm the execution of desired pathways yield desired results

Relates to #63