### PR TITLE
feat(character): skip mount and minion fetches for characters where page is disabled

### DIFF
--- a/src/main/java/com/ffxivcensus/gatherer/player/PlayerBuilder.java
+++ b/src/main/java/com/ffxivcensus/gatherer/player/PlayerBuilder.java
@@ -51,6 +51,7 @@ public class PlayerBuilder {
     private static final String LAYOUT_CHARACTER_BLOCK_BOX = "character-block__box";
     private static final String LAYOUT_FRAME_CHARA_WORLD = "frame__chara__world";
     private static final String LAYOUT_CHARACTER_BLOCK_NAME = "character-block__name";
+	private static final String LAYOUT_CHARACTER_TAB = "character_menu__link";
     private static final Logger LOG = LoggerFactory.getLogger(PlayerBuilder.class);
     /**
      * Number of days inactivity before character is considered inactive
@@ -195,20 +196,29 @@ public class PlayerBuilder {
             Document classJobDoc = pageLoader.getClassJobPage(playerID);
             setLevels(player, getLevelsFromPage(classJobDoc));
 
-            // Mounts from the relevant sub-section
-			try {
-				Document mountDoc = pageLoader.getMountPage(playerID);
-				player.setMounts(getMountsFromPage(mountDoc));
-			} catch (FetchYieldedPageNotFoundException e) {
+			if (isPlayerTabDisabled(doc, "Mounts")) {
 				player.setMounts(new ArrayList<>());
+			} else {
+				// Mounts from the relevant sub-section
+				try {
+					Document mountDoc = pageLoader.getMountPage(playerID);
+					player.setMounts(getMountsFromPage(mountDoc));
+				} catch (FetchYieldedPageNotFoundException e) {
+					player.setMounts(new ArrayList<>());
+				}
 			}
 
-            // Minions from the relevant sub-section
-			try {
-				Document minionDoc = pageLoader.getMinionPage(playerID);
-				player.setMinions(getMinionsFromPage(minionDoc));
-			} catch (FetchYieldedPageNotFoundException e) {
+
+			if (isPlayerTabDisabled(doc, "Minions")) {
 				player.setMinions(new ArrayList<>());
+			} else {
+				// Minions from the relevant sub-section
+				try {
+					Document minionDoc = pageLoader.getMinionPage(playerID);
+					player.setMinions(getMinionsFromPage(minionDoc));
+				} catch (FetchYieldedPageNotFoundException e) {
+					player.setMinions(new ArrayList<>());
+				}
 			}
 
             // Info based on the result of grabbing Mounts & Minions
@@ -284,6 +294,10 @@ public class PlayerBuilder {
         return player.getDateImgLastModified().after(nowMinusIncludeRange); // If the date occurs between the include range and now, then
                                                                             // return true. Else false
     }
+
+	private boolean isPlayerTabDisabled(final Document doc, final String tabName) {
+		return doc.select(".character__profile_tab > li:contains("+tabName+")").hasClass("disable");
+	}
 
     /**
      * Given a lodestone profile page, return the name of the character.

--- a/src/main/java/com/ffxivcensus/gatherer/player/PlayerBuilder.java
+++ b/src/main/java/com/ffxivcensus/gatherer/player/PlayerBuilder.java
@@ -51,7 +51,7 @@ public class PlayerBuilder {
     private static final String LAYOUT_CHARACTER_BLOCK_BOX = "character-block__box";
     private static final String LAYOUT_FRAME_CHARA_WORLD = "frame__chara__world";
     private static final String LAYOUT_CHARACTER_BLOCK_NAME = "character-block__name";
-	private static final String LAYOUT_CHARACTER_TAB = "character_menu__link";
+	private static final String LAYOUT_CHARACTER_TAB = "character__profile_tab";
     private static final Logger LOG = LoggerFactory.getLogger(PlayerBuilder.class);
     /**
      * Number of days inactivity before character is considered inactive
@@ -296,7 +296,7 @@ public class PlayerBuilder {
     }
 
 	private boolean isPlayerTabDisabled(final Document doc, final String tabName) {
-		return doc.select(".character__profile_tab > li:contains("+tabName+")").hasClass("disable");
+		return doc.select("."+LAYOUT_CHARACTER_TAB+" > li:contains("+tabName+")").hasClass("disable");
 	}
 
     /**

--- a/src/test/java/com/ffxivcensus/gatherer/player/PlayerBuilderTest.java
+++ b/src/test/java/com/ffxivcensus/gatherer/player/PlayerBuilderTest.java
@@ -1,12 +1,11 @@
 package com.ffxivcensus.gatherer.player;
 
-import static org.junit.Assert.*;
-
+import com.ffxivcensus.gatherer.edb.EorzeaDatabaseCache;
+import com.ffxivcensus.gatherer.lodestone.TestDataLodestonePageLoader;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.ffxivcensus.gatherer.edb.EorzeaDatabaseCache;
-import com.ffxivcensus.gatherer.lodestone.TestDataLodestonePageLoader;
+import static org.junit.Assert.*;
 
 public class PlayerBuilderTest {
 
@@ -82,7 +81,7 @@ public class PlayerBuilderTest {
         assertEquals(25, player.getLevelMiner());
         assertEquals(80, player.getLevelBotanist());
         assertEquals(87, player.getLevelFisher());
-        
+
         // Bozjan Southern Front
         assertEquals(25, player.getLevelBozja());
 
@@ -148,6 +147,29 @@ public class PlayerBuilderTest {
         // Test for data from very end
         assertTrue(player.getMounts().contains("Midgardsormr"));
     }
+
+
+	@Test
+	public void testLoadFrom33000061() throws Exception {
+		instance.setPageLoader(new TestDataLodestonePageLoader());
+		PlayerBean player = instance.getPlayer(33000061);
+
+		assertEquals(33000061, player.getId());
+		assertTrue(player.getMinions().size() == 0);
+		assertTrue(player.getMounts().size() > 0);
+
+	}
+
+	@Test
+	public void testLoadFrom33000046() throws Exception {
+		instance.setPageLoader(new TestDataLodestonePageLoader());
+		PlayerBean player = instance.getPlayer(33000046);
+
+		assertEquals(33000046, player.getId());
+		assertTrue(player.getMinions().size() > 0);
+		assertTrue(player.getMounts().size() == 0);
+
+	}
 
     @Test
     public void testLoadFrom22763008() throws Exception {

--- a/src/test/resources/data/lodestone/Character-33000046-Class-Jobs.html
+++ b/src/test/resources/data/lodestone/Character-33000046-Class-Jobs.html
@@ -1,0 +1,1817 @@
+<!DOCTYPE html>
+<html lang="en-gb" class="en-gb" xmlns:og="http://ogp.me/ns#" xmlns:fb="http://www.facebook.com/2008/fbml">
+<head><meta charset="utf-8">
+
+	<!-- Google Tag Manager -->
+	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	})(window,document,'script','digitalData','GTM-P37XSWJ');</script>
+	<!-- End Google Tag Manager -->
+
+	<title>K&#39;ewl D&#39;eeps | FINAL FANTASY XIV, The Lodestone</title>
+	<meta name="description" content="Character profile for K&#39;ewl D&#39;eeps.">
+	<meta name="keywords" content="FF14,FFXIV,Final Fantasy XIV,Final Fantasy 14,Lodestone,players' site,community site,A Realm Reborn,Heavensward,Stormblood,Shadowbringers,Endwalker,MMO">
+	<meta name="author" content="SQUARE ENIX Ltd.">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="format-detection" content="telephone=no">
+
+	<link rel="shortcut icon" type="image/vnd.microsoft.icon" href="https://img.finalfantasyxiv.com/lds/pc/global/images/favicon.ico?1490749553">
+	<link rel="apple-touch-icon-precomposed" href="https://img.finalfantasyxiv.com/lds/h/0/U2uGfVX4GdZgU1jASO0m9h_xLg.png">
+	<meta name="msapplication-TileImage" content="https://img.finalfantasyxiv.com/lds/h/0/U2uGfVX4GdZgU1jASO0m9h_xLg.png">
+
+	<meta name="msapplication-TileColor" content="#000000">
+	<link rel="alternate" hreflang="ja" href="https://jp.finalfantasyxiv.com/lodestone/character/33000046/class_job/">
+	<link rel="alternate" hreflang="en-us" href="https://na.finalfantasyxiv.com/lodestone/character/33000046/class_job/">
+	<link rel="alternate" hreflang="fr" href="https://fr.finalfantasyxiv.com/lodestone/character/33000046/class_job/">
+	<link rel="alternate" hreflang="de" href="https://de.finalfantasyxiv.com/lodestone/character/33000046/class_job/">
+
+
+	<meta name="google-site-verification" content="WwpBRGfcVWgP_LxTs8PHc6EcDM8eCt8Zqck1MAnVmZM">
+
+
+
+
+	<!--[if lt IE 9]>
+	<script src="https://img.finalfantasyxiv.com/lds/h/I/SMlNRnAvuilc1lYKBpzKWpmADs.js"></script>
+
+	<![endif]-->
+	<!-- ** CSS ** -->
+	<link href="https://img.finalfantasyxiv.com/lds/h/M/0kxkkawCCBg1ArBrU_c1cydINM.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/-/tUrZCLFtMgzaHil2OXxbmdw2a0.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/l/6D7j33OWZQd8eVk8IKWT15deH8.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/j/JgAulXN0McN_xRNcKLLbnNh4fs.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/F/wZHqGlYFe-0or10VJJtARsKyko.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/a/bmAvctt6TxsMwvFeI4NiKcWnZM.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/Q/mAASajjDE39sDOGkuOPDZPBt0s.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/w/YgRYdK0dq3N9UCU6nR-7J5PftA.css" rel="stylesheet">
+
+	<link href="https://img.finalfantasyxiv.com/lds/h/b/tInX1HM2lXTimf4ts8i-7wWr1Y.css" rel="stylesheet">
+
+	<link href="https://img.finalfantasyxiv.com/lds/h/w/cuKVxIZUo5Tf3xQ8a9_mn8jZDU.css" rel="stylesheet"
+		  class="sys_theme_css"
+
+		  data-theme_white="https://img.finalfantasyxiv.com/lds/h/w/cuKVxIZUo5Tf3xQ8a9_mn8jZDU.css"
+
+		  data-theme_black="https://img.finalfantasyxiv.com/lds/h/o/q3zLnccpt9t--buuJJqeuTpzOY.css"
+
+	>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<!-- ogp -->
+	<meta property="fb:app_id" content="1400886233468625">
+	<meta property="og:type" content="website">
+	<meta property="og:description" content="Character profile for K&#39;ewl D&#39;eeps.">
+	<meta property="og:title" content="K&#39;ewl D&#39;eeps | FINAL FANTASY XIV, The Lodestone">
+	<meta property="og:url" content="https://eu.finalfantasyxiv.com/lodestone/character/33000046/class_job/">
+	<meta property="og:site_name" content="FINAL FANTASY XIV, The Lodestone">
+	<meta property="og:locale" content="en_GB">
+
+	<meta property="og:image" content="https://img.finalfantasyxiv.com/lds/h/I/cy_FoBlOdFg3kBAQdaAxT19pTw.png">
+
+
+
+	<meta property="fb:pages" content="116214575870">
+
+
+	<meta name="twitter:card" content="summary_large_image">
+
+	<meta name="twitter:site" content="@ff_xiv_en">
+
+
+
+
+	<script>
+		var base_domain = 'finalfantasyxiv.com';
+		var ldst_subdomain = 'eu';
+		var strftime_fmt = {
+			'dateHHMM_now': 'Today %H:%M',
+			'dateYMDHMS': '%d/%m/%Y %H:%M:%S',
+			'dateYMDHM': '%d/%m/%Y %H:%M',
+			'dateYMDHM_jp': '%Y/%m/%d %H:%M',
+			'dateHM': '%H:%M',
+			'dateYMDH': '%d/%m/%Y %H',
+			'dateYMD': '%d/%m/%Y',
+			'dateEternal': '%d.%m.%Y',
+			'dateYMDW': '%d/%m/%Y (%a)',
+			'dateHM': '%H:%M',
+			'week.0': 'Sun.',
+			'week.1': 'Mon.',
+			'week.2': 'Tue.',
+			'week.3': 'Wed.',
+			'week.4': 'Thu.',
+			'week.5': 'Fri.',
+			'week.6': 'Sat.'
+		};
+		var base_uri   = '/lodestone/';
+		var api_uri    = '/lodestone/api/';
+		var static_uri = 'https://img.finalfantasyxiv.com/lds/';
+		var subdomain  = 'eu';
+		var csrf_token = 'b726b2475aab6e2b29c16ddcf48f50e5e7d76211';
+		var cis_origin = 'https://secure.square\u002denix.com';
+		var ldst_max_image_size = 31457280;
+		var eorzeadb = {
+			cdn_prefix: 'https://img.finalfantasyxiv.com/lds/',
+			version: '1641278251',
+			version_js_uri:  'https://img.finalfantasyxiv.com/lds/pc/global/js/eorzeadb/version.js',
+			dynamic_tooltip: false
+		};
+		var cookie_suffix = '';
+		var ldst_is_loggedin = false;
+		var show_achievement = false;
+	</script>
+	<script src="https://img.finalfantasyxiv.com/lds/h/A/PknAmzDJUZCNhTGtSGGMIGi5k4.js"></script>
+	<script src="https://img.finalfantasyxiv.com/lds/h/H/hBuD3_ZXTqwHX64YYCchtvgGSs.js"></script>
+
+
+
+
+
+
+
+
+
+</head>
+<body id="community" class=" lang_eu">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P37XSWJ"
+				  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+
+
+
+<div class="brand"><div class="brand__section">
+	<div class="brand__logo">
+		<a href="
+				https://square-enix-games.com/en_GB
+			" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/h/L/cxcD5kjeM52JRVwrrzIF4dZNe0.png" width="130" height="14" alt="SQUARE ENIX">
+		</a>
+	</div>
+
+
+	<div class="brand__search">
+		<form action="/lodestone/community/search/" class="brand__search__form">
+			<div class="brand__search__focus_bg"></div>
+			<div class="brand__search__base_bg"></div>
+			<input type="text" id="txt_search" class="brand__search--text" name="q" placeholder="Search">
+			<input type="submit" id="bt_search" class="brand__search--btn" value="">
+		</form>
+	</div>
+
+
+
+	<div class="brand__theme sys_theme_switcher">
+		<a href="javascript:void(0);"><i class="brand__theme--white sys_theme active js__tooltip" data-tooltip="Theme (Black)" data-theme="white"></i></a>
+		<a href="javascript:void(0);"><i class="brand__theme--black sys_theme js__tooltip" data-tooltip="Theme (White)" data-theme="black"></i></a>
+	</div>
+
+
+	<div class="brand__lang dropdown_trigger_box">
+		<a href="javascript:void(0);" class="brand__lang__btn brand__lang__en-gb dropdown_trigger">English</a>
+		<ul class="brand__lang__select dropdown">
+
+			<li><a href="https://jp.finalfantasyxiv.com/lodestone/character/33000046/class_job/" class="brand__lang__jp">日本語</a></li>
+
+			<li><a href="https://na.finalfantasyxiv.com/lodestone/character/33000046/class_job/" class="brand__lang__na">English</a></li>
+
+			<li><a href="https://eu.finalfantasyxiv.com/lodestone/character/33000046/class_job/" class="brand__lang__eu">English</a></li>
+
+			<li><a href="https://fr.finalfantasyxiv.com/lodestone/character/33000046/class_job/" class="brand__lang__fr">Français</a></li>
+
+			<li><a href="https://de.finalfantasyxiv.com/lodestone/character/33000046/class_job/" class="brand__lang__de">Deutsch</a></li>
+
+		</ul>
+	</div>
+
+
+
+	<div class="l__cross_menu eu">
+		<a href="javascript:void(null)" class="ffxiv_pr_cross_menu_button_eu"></a>
+		<script>
+			var ffxiv_pr_cross_menu = {
+				uri_js: '/cross_menu/uri.js'
+			};
+		</script>
+		<script src="https://img.finalfantasyxiv.com/lds/promo/pc/global/menu/loader.js"></script>
+	</div>
+
+</div></div>
+
+
+
+
+<header class="l__header">
+	<div class="l__header__inner l__header__bg_image" style="background-image: url(https://img.finalfantasyxiv.com/lds/banner/1074/headerImage_6_0_eu.jpg);">
+		<a href="/lodestone/" class="l__header__link_top"></a>
+
+
+		<a href="/lodestone/topics/detail/66a742165e9415790247c1a1f7d909abf5becb5c/?utm_source=lodestone&amp;utm_medium=pc_header&amp;utm_campaign=eu_6_0patch" class="l__header__link_management"></a>
+
+
+		<div class="l__header__login clearfix"><a href="/lodestone/account/login/" class="l__header__login__btn">
+			<img src="https://img.finalfantasyxiv.com/lds/h/z/6PLTZ82M99GJ7tKOee1RSwvNrQ.png" width="40" height="40" alt="" class="l__header__login__chara_silhouette">
+			<div class="l__header__login__txt">
+				<p>View Your Character Profile</p>
+				<div>Log In</div>
+			</div>
+		</a></div>
+
+
+	</div>
+</header>
+
+
+
+
+
+
+
+
+
+
+<div class="global-nav">
+	<nav class="main-nav eu">
+		<ul class="main-nav__area main-nav__area__community clearfix ">
+			<li class="main-nav__news main-nav__item">
+				<a href="/lodestone/news/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_news-top');"><span>News</span></a>
+				<nav class="sub-nav">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__news">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__news__icon">
+									<li>
+										<a href="/lodestone/news/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_top');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/8/2GwuzUcvqLa-hgQeLUyd8xarI8.png" width="32" height="32" alt="News">
+											News
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/topics/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_topics');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/5/67ZyAIzQUaYoWBmyvFwNvGmCnQ.png" width="32" height="32" alt="Topics">
+											Topics
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/1" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_notices');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/-/Y5JdwnEWYfyO7OlH27eKIm91Ok.png" width="32" height="32" alt="Notices">
+											Notices
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/2" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_maintenance');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/s/-JfULvMAf26L7AaU1OGaGYwanI.png" width="32" height="32" alt="Maintenance">
+											Maintenance
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/3" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_updates');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/p/HPudyOQcwdv97RBwj3FQC552ps.png" width="32" height="32" alt="Updates">
+											Updates
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/4" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_Status');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/S/-IC2xIQhTl2ymYW7deE1fOII04.png" width="32" height="32" alt="Status">
+											Status
+										</div></a>
+									</li>
+								</ul>
+								<ul class="sub-nav__news__text">
+									<li><a href="/lodestone/special/patchnote_log/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_patch-notes_special-sites');"><div>
+										Patch Notes and Special Sites
+										<span class="update">
+											Updated <span id="datetime-36dc0d21a06">-</span><script>document.getElementById('datetime-36dc0d21a06').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</div></a></li>
+									<li><a href="/lodestone/special/update_log/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_lodestone-update-notes');"><div>
+										<span class="sub_text">Official Community Site</span>
+										The Lodestone Update Notes
+										<span class="update">
+											Updated <span id="datetime-8566e85430c">-</span><script>document.getElementById('datetime-8566e85430c').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</div></a></li>
+									<li><a href="/lodestone/worldstatus/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_server-status');"><div>
+										Server Status
+									</div></a></li>
+								</ul>
+							</div>
+						</div>
+
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__promotion main-nav__item">
+				<a href="/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_begin-ff14-top');"><span>Getting Started</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__promotion">
+							<div class="sub-nav__list__inner">
+								<div class="sub-nav__promotion__inner">
+									<div class="sub-nav__promotion__link">
+										<div class="sub-nav__promotion__top">
+											<a href="/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_pr');"><img src="https://img.finalfantasyxiv.com/lds/h/P/ciPXy1S4-ssQuLQJvEF4JWVm5Q.jpg" width="632" height="140" alt="FINAL FANTASY XIV: A Realm Reborn"></a>
+										</div>
+										<ul class="sub-nav__promotion__page">
+											<li><a href="/benchmark/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_benchmark');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/S/2_8ofX4E90a7pS-p0mjFK_tc_U.png" width="64" height="40" alt="Benchmark">
+												<span>Benchmark</span>
+											</a></li>
+											<li><a href="
+
+													http://freetrial.finalfantasyxiv.com/
+												" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_freetrial');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/c/tWvZpXDc_g6yQd5YKK2k5jhuns.png" width="64" height="40" alt="Free Trial">
+												<span>Free Trial</span>
+											</a></li>
+											<li><a href="/product/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_product');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/m/NCNLGrn3U9M85ky-NscraujvN8.png" width="64" height="40" alt="Product">
+												<span>Product</span>
+											</a></li>
+											<li><a href="/winning/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_awards');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/j/udWU20sWmhYoEsQ_FtrAzVwJ3Q.png" width="64" height="40" alt="Awards and Nominations">
+												<span>Awards and Nominations</span>
+											</a></li>
+										</ul>
+									</div>
+									<div class="sub-nav__promotion__patch_site">
+										<a href="/endwalker/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_latest-expansion');"><span>
+											<img src="https://img.finalfantasyxiv.com/lds/h/f/sLzgsq-NNdSMdqLt6Mby4oROC0.png" width="296" height="232" alt="FINAL FANTASY XIV: Endwalker Special Site">
+										</span></a>
+									</div>
+								</div>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+			</li>
+			<li class="main-nav__playguide main-nav__item">
+				<a href="/lodestone/playguide/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_playguide-top');"><span>Play Guide</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__playguide">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__playguide__list">
+									<li><a href="/lodestone/playguide/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_playguide-top');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/P/Lfl3LVb9KMPa5Ye8yxftZkelbc.png" width="40" height="40" alt="Play Guide<br />Top">
+										<span>Play Guide<br />Top</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#game_playguide" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_game-playguide');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/q/qy4dUGMNkjoyVqPweYMIpOApik.png" width="40" height="40" alt="Gameplay Guide and<br />Beginners' Guide">
+										<span>Gameplay Guide and<br />Beginners' Guide</span>
+										<span class="update">
+											Updated <span id="datetime-ac79d9888d6">-</span><script>document.getElementById('datetime-ac79d9888d6').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/db/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_databese');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/N/OYPWhQVCkovUbVcMMck0O4HABU.png" width="40" height="40" alt="Eorzea Database">
+										<span>Eorzea Database</span>
+										<span class="update">
+											Updated <span id="datetime-480e9f8a27a">-</span><script>document.getElementById('datetime-480e9f8a27a').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#content_guide" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_contents-guide');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/W/wlHP1NMpdQHcPKUG-swlv71fhE.png" width="40" height="40" alt="Game Features">
+										<span>Game Features</span>
+										<span class="update">
+											Updated <span id="datetime-7c300fc6d4b">-</span><script>document.getElementById('datetime-7c300fc6d4b').innerHTML = ldst_strftime(1638518400, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#side_storyes" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_side-story');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/Z/1QWgBsVU7ZboWyMZlRjCQcDRJg.png" width="40" height="40" alt="Side Stories<br />and More">
+										<span>Side Stories<br />and More</span>
+										<span class="update">
+											Updated <span id="datetime-3734b8699fc">-</span><script>document.getElementById('datetime-3734b8699fc').innerHTML = ldst_strftime(1632470400, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#option_service" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_option-service');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/4fXwcEoJzDEmFRt-tD7PeeKvjE.png" width="40" height="40" alt="Additional Services">
+										<span>Additional Services</span>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__community main-nav__item">
+				<a href="/lodestone/community/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_community-top');"><span>Community</span></a>
+				<nav class="sub-nav">
+					<div class="sub-nav__area">
+
+
+						<div class="sub-nav__list sub-nav__community">
+							<div class="sub-nav__list__inner sub-nav__community__flex">
+								<div class="sub-nav__community__link">
+									<div class="sub-nav__community__top">
+										<div class="sub-nav__community__top__wrapper">
+											<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/q/GiEpnP3oCXluFjrlPlM-mgIbS8.png" width="16" height="16" alt="Community">Community</h2>
+											<ul class="sub-nav__community__list">
+												<li><a href="/lodestone/community/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_community-top');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/i/Sa5YF2-VFf4IJ1cjjFAbPf4GWg.png" width="40" height="40" alt="Community Wall">
+													<span>Community Wall</span>
+												</a></li>
+												<li><a href="/lodestone/blog/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_blog');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/h/6gPbLbzUQ_omC_mdXFUA3zPy7I.png" width="40" height="40" alt="Blog">
+													<span>Blog</span>
+												</a></li>
+											</ul>
+										</div>
+										<div class="sub-nav__community__top__wrapper">
+											<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/d/in_Sbc6SzxLU--Npa7URI-_kdg.png" width="16" height="16" alt="Member Recruitment">Member Recruitment</h2>
+											<ul class="sub-nav__community__list">
+												<li><a href="/lodestone/community_finder/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_community-finder');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/V/kHxwEjpY-Fme83ta8VIfi1kyLU.png" width="40" height="40" alt="Community Finder">
+													<span>Community Finder</span>
+												</a></li>
+												<li><a href="/lodestone/event/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_event-party');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/0/k5jD6-BJZHwKA2CtbNcDYZR6oY.png" width="40" height="40" alt="Event & Party Recruitment">
+													<span>Event & Party Recruitment</span>
+												</a></li>
+											</ul>
+										</div>
+									</div>
+									<div class="sub-nav__community__search">
+										<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/X/uQVT3DEl1xlFWHu3UZU4-RBtVk.png" width="16" height="16" alt="Search">Search</h2>
+										<ul class="sub-nav__community__list sub-nav__community__search__list">
+											<li><a href="/lodestone/character/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_chara-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/5/YcEF3K-5SgqU0BxZtT0D1Zsa2A.png" width="40" height="40" alt="Character Search">
+												<span>Character Search</span>
+											</a></li>
+											<li><a href="/lodestone/linkshell/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_ls-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/b/SPCgcBAk4HvMngGzk6H4MfSINg.png" width="40" height="40" alt="Linkshell Search">
+												<span>Linkshell Search</span>
+											</a></li>
+											<li><a href="/lodestone/crossworld_linkshell/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_cwls-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/L/NUGcPcy-C8jvx6oKgEXgwJ1ePE.png" width="40" height="40" alt="CWLS Search ">
+												<span>CWLS Search </span>
+											</a></li>
+											<li><a href="/lodestone/freecompany/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_fc-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/q/GJ-lsgAtsCCDwCm9te3a5sCjpU.png" width="40" height="40" alt="Free Company Search">
+												<span>Free Company Search</span>
+											</a></li>
+											<li><a href="/lodestone/pvpteam/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_pvp-team-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="PvP Team Search">
+												<span>PvP Team Search</span>
+											</a></li>
+										</ul>
+									</div>
+								</div>
+								<div class="sub-nav__community__side">
+									<div class="sub-nav__community__forum">
+										<ul class="sub-nav__community__forum__list">
+											<li><a href="https://forum.square-enix.com/ffxiv/forum.php" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum');">
+												<div class="forum">
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/r/maZ-sHaqn4PMFANUlbH4GzztFM.png" width="40" height="40" alt="Forums">
+													</i><span>Forums</span>
+												</div>
+											</a></li>
+											<li><a href="https://forum.square-enix.com/ffxiv/search.php?do=getdaily_ll&contenttype=vBForum_Post" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum-new-posts');">
+												<div>
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+													</i><span>New Posts</span>
+												</div>
+											</a></li>
+											<li><a href="
+
+														https://forum.square-enix.com/ffxiv/search.php?do=process&search_type=1&contenttypeid=1&devtrack=1&starteronly=0&showposts=1&childforums=1&forumchoice[]=619
+													" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum-dev-tracker');">
+												<div>
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+													</i><span>Dev Tracker</span>
+												</div>
+											</a></li>
+										</ul>
+									</div>
+									<ul class="sub-nav__community__fankit">
+										<li><a href="/lodestone/special/fankit/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_fankit');">
+											<div>
+												<span>Fan Kit</span>
+												<span class="update">
+													Updated <span id="datetime-5884d43598d">-</span><script>document.getElementById('datetime-5884d43598d').innerHTML = ldst_strftime(1640332800, 'YMD');</script>
+												</span>
+											</div>
+										</a></li>
+									</ul>
+								</div>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__ranking main-nav__item">
+				<a href="/lodestone/ranking/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_ranking-top');"><span>Standings</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__ranking">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__ranking__list">
+									<li><a href="/lodestone/ranking/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_ranking-top');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/E/NtymEFiUJfAh25ffTrADsVFkLQ.png" width="40" height="40" alt="Standings Top">
+										<span>Standings Top</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/thefeast/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_feast');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="The Feast Rankings">
+										<span>The Feast Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/deepdungeon2/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_deepdungeon2');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/_/qP22LgUoAFKDTRayb_TEYu6d7g.png" width="40" height="40" alt="Heaven-on-High Rankings">
+										<span>Heaven-on-High Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/deepdungeon/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_deepdungeon');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/p/op9iPrlMmYgTK3Q6NQKifyQOGA.png" width="40" height="40" alt="Palace of the Dead Rankings">
+										<span>Palace of the Dead Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/frontline/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_frontline');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="Frontline Standings">
+										<span>Frontline Standings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/gc/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_gc');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/o/uRmujlTx4X_5c6wETNxssK1d_4.png" width="40" height="40" alt="Grand Company Standings">
+										<span>Grand Company Standings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/fc/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_fc');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/q/GJ-lsgAtsCCDwCm9te3a5sCjpU.png" width="40" height="40" alt="Free Company Standings">
+										<span>Free Company Standings</span>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__help main-nav__item">
+				<a href="/lodestone/help/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_help-support-top');"><span>Help & Support</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__help">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__help__list">
+									<li><a href="/lodestone/help/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_help-support-top');">
+										<span>Help & Support</span>
+									</a></li>
+									<li><a href="/lodestone/help/about_the_lodestone/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_about-lodestone');">
+										<span>About the Lodestone</span>
+									</a></li>
+									<li><a href="
+
+											https://support.eu.square-enix.com/faq.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_faq');">
+										<span>FAQ</span>
+									</a></li>
+									<li><a href="
+
+											https://eu.square-enix.com/en/seaccount/
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_sqex-account');">
+										<span>Square Enix Account Information</span>
+									</a></li>
+								</ul>
+								<ul class="sub-nav__help__other">
+									<li><a href="
+
+											https://support.eu.square-enix.com/rule.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_rule-policies');">
+										<div>
+											<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+											</i><span>Rules & Policies</span>
+										</div>
+									</a></li>
+									<li><a href="
+
+											https://support.eu.square-enix.com/main.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_customer-service');">
+										<div>
+											<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+											</i><span>Customer Service</span>
+										</div>
+									</a></li>
+									<li><a href="https://sqex.to/Msp" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_mogstation');">
+										<div>
+											<i class="ic_mogst"><img src="https://img.finalfantasyxiv.com/lds/h/S/6IKp0hN6xQqTYPgnPIsd2fjzSI.png" width="32" height="32" alt="">
+											</i><span>Mog Station</span>
+										</div>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+		</ul>
+	</nav>
+</div>
+
+
+
+
+<div class="ldst__bg">
+
+	<div id="breadcrumb">
+		<ul itemscope itemscope itemtype="https://schema.org/BreadcrumbList" class="clearfix">
+			<li class="breadcrumb__home" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/" itemprop="item"><span itemprop="name">HOME</span></a>
+				<meta itemprop="position" content="1" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/community/" itemprop="item" class="breadcrumb__link"><span itemprop="name">Community</span></a>
+				<meta itemprop="position" content="2" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/character/" itemprop="item" class="breadcrumb__link"><span itemprop="name">Character</span></a>
+				<meta itemprop="position" content="3" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<span itemprop="name">K&#39;ewl D&#39;eeps</span>
+				<meta itemprop="position" content="4" />
+			</li>
+
+
+		</ul>
+	</div>
+
+
+	<h1 class="heading__title">Character</h1>
+
+
+
+	<nav class="btn__corner_block">
+		<ul class="btn__corner_block--3">
+
+			<li>
+				<a href="/lodestone/character/33000046/" class="btn__menu btn__menu--active">Profile</a>
+			</li>
+			<li>
+				<a href="/lodestone/character/33000046/blog/" class="btn__menu">Blog</a>
+			</li>
+			<li>
+				<a href="/lodestone/character/33000046/event/" class="btn__menu">Events</a>
+			</li>
+
+		</ul>
+	</nav>
+
+
+
+	<div class="ldst__contents clearfix">
+
+		<div class="ldst__main">
+
+
+
+			<div id="character" class="ldst__window">
+				<h2 class="heading--lg">Character</h2>
+
+
+
+				<div class="frame__chara js__toggle_wrapper">
+					<a href="/lodestone/character/33000046/" class="frame__chara__link">
+						<div class="frame__chara__face">
+							<img src="https://img2.finalfantasyxiv.com/f/197341aa090981d3cf179d2703eb85bc_284358f8eb4efc9095914e46798c6ab3fc0_96x96.jpg?1642767359" width="40" height="40" alt="">
+						</div>
+						<div class="frame__chara__box">
+
+							<p class="frame__chara__name">K&#39;ewl D&#39;eeps</p>
+
+							<p class="frame__chara__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Coeurl&nbsp;(Crystal)</p>
+						</div>
+					</a>
+					<div class="parts__connect--state js__toggle_trigger">
+
+
+						<i class="parts__connect_off js__tooltip" data-tooltip="You have no connection with this character."></i>
+
+					</div>
+
+					<div class="parts__switch js__toggle_item">
+
+						<p class="character__connect__text">You have no connection with this character.</p>
+
+
+
+
+
+						<div class="heading--md-slide">Follower Requests</div>
+						<p class="entry__toggle__text">Before this character can be followed, you must first submit a follower request.<br />Do you wish to proceed?</p>
+						<ul class="btn__switch character__connect__form">
+							<li><a href="/lodestone/account/login/">Yes</a></li>
+							<li><a href="javascript:void(0)" class="js__toggle_trigger">No</a></li>
+						</ul>
+
+
+
+					</div>
+
+				</div>
+
+				<ul class="character__profile_tab js__character_menu clearfix"><li><a href="/lodestone/character/33000046/#profile">Profile</a></li><li class="character_menu__link"><a href="javascript:void(null)" class="selected">Class/Job</a></li><li class="character_menu__link"><a href="/lodestone/character/33000046/minion/">Minions</a></li><li class="disable"><span class="disable">Mounts</span></li><li class="character_menu__link"><a href="/lodestone/character/33000046/following/">Follow</a></li></ul>
+
+
+
+				<div class="character__content selected">
+
+
+
+
+					<h3 class="heading--md">DoW/DoM</h3>
+					<div class="clearfix">
+						<div class="character__job__role">
+							<h4 class="heading--lead"><img src="https://img.finalfantasyxiv.com/lds/h/Q/e8-CIpHMk6D5Dau_tyTx0Kt9js.png" width="24" height="24" class="character__job__icon__title">Tank</h4>
+							<ul class="character__job clearfix">
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/U/F5JzG9RPIKFSogtaKNBk455aYA.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Gladiator"
+
+									>Gladiator</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/N/St9rjDJB3xNKGYg-vwooZ4j6CM.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Marauder"
+
+									>Marauder</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/l/5CZEvDOMYMyVn2td9LZigsgw9s.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Dark Knight"
+
+									>Dark Knight</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/8/hg8ofSSOKzqng290No55trV4mI.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Gunbreaker"
+
+									>Gunbreaker</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+							</ul>
+						</div>
+						<div class="character__job__role">
+							<h4 class="heading--lead"><img src="https://img.finalfantasyxiv.com/lds/h/8/iUDBiCamMS05753pYarJPvRBkg.png" width="24" height="24" class="character__job__icon__title">Healer</h4>
+							<ul class="character__job clearfix">
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/s/gl62VOTBJrm7D_BmAZITngUEM8.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Conjurer"
+
+									>Conjurer</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/7/WdFey0jyHn9Nnt1Qnm-J3yTg5s.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Scholar"
+
+									>Scholar</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/1/erCgjnMSiab4LiHpWxVc-tXAqk.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Astrologian"
+
+									>Astrologian</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/g/_oYApASVVReLLmsokuCJGkEpk0.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Sage"
+
+									>Sage</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+							</ul>
+						</div>
+					</div>
+					<div class="clearfix">
+						<div class="character__job__role">
+							<h4 class="heading--lead"><img src="https://img.finalfantasyxiv.com/lds/h/V/d9PjsFG2F8p1wwBkwcpOzoETRQ.png" width="24" height="24" class="character__job__icon__title">Melee DPS</h4>
+							<ul class="character__job clearfix">
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/K/HW6tKOg4SOJbL8Z20GnsAWNjjM.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">39</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Monk / Pugilist"
+
+									>Monk</div>
+									<div class="character__job__exp">0 / 142,000</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/k/tYTpoSwFLuGYGDJMff8GEFuDQs.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Lancer"
+
+									>Lancer</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/y/wdwVVcptybfgSruoh8R344y_GA.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Rogue"
+
+									>Rogue</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/m/KndG72XtCFwaq1I1iqwcmO_0zc.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Samurai"
+
+									>Samurai</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/7/cLlXUaeMPJDM2nBhIeM-uDmPzM.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Reaper"
+
+									>Reaper</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+							</ul>
+						</div>
+						<div class="character__job__role">
+							<h4 class="heading--lead"><img src="https://img.finalfantasyxiv.com/lds/h/v/jkXOruroSp9ATWIA43ZiFGQB1Y.png" width="24" height="24" class="character__job__icon__title">Physical Ranged DPS</h4>
+							<ul class="character__job clearfix">
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/Q/ZpqEJWYHj9SvHGuV9cIyRNnIkk.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Archer"
+
+									>Archer</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/E/vmtbIlf6Uv8rVp2YFCWA25X0dc.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Machinist"
+
+									>Machinist</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/t/HK0jQ1y7YV9qm30cxGOVev6Cck.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Dancer"
+
+									>Dancer</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+							</ul>
+							<h4 class="heading--lead"><img src="https://img.finalfantasyxiv.com/lds/h/b/z3xeul_dFgcxt4E1MhigrzMDVE.png" width="24" height="24" class="character__job__icon__title">Magical Ranged DPS</h4>
+							<ul class="character__job clearfix">
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/4/IM3PoP6p06GqEyReygdhZNh7fU.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Thaumaturge"
+
+									>Thaumaturge</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/e/VYP1LKTDpt8uJVvUT7OKrXNL9E.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Arcanist"
+
+									>Arcanist</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/q/s3MlLUKmRAHy0pH57PnFStHmIw.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Red Mage"
+
+									>Red Mage</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/p/jdV3RRKtWzgo226CC09vjen5sk.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+										 data-tooltip="Blue Mage (Limited Job)"
+
+									>Blue Mage</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+							</ul>
+						</div>
+					</div>
+
+					<h3 class="heading--md">DoH/DoL</h3>
+					<div class="clearfix">
+						<div class="character__job__role">
+							<h4 class="heading--lead"><img src="https://img.finalfantasyxiv.com/lds/h/6/SX0lXLnrhyf1oQQ3aCra-PIjD8.png" width="24" height="24" class="character__job__icon__title">Disciples of the Hand</h4>
+							<ul class="character__job clearfix">
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/v/YCN6F-xiXf03Ts3pXoBihh2OBk.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Carpenter"
+
+									>Carpenter</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/5/EEHVV5cIPkOZ6v5ALaoN5XSVRU.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Blacksmith"
+
+									>Blacksmith</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/G/Rq5wcK3IPEaAB8N-T9l6tBPxCY.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Armorer"
+
+									>Armorer</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/L/LbEjgw0cwO_2gQSmhta9z03pjM.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Goldsmith"
+
+									>Goldsmith</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/b/ACAcQe3hWFxbWRVPqxKj_MzDiY.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Leatherworker"
+
+									>Leatherworker</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/X/E69jrsOMGFvFpCX87F5wqgT_Vo.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Weaver"
+
+									>Weaver</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/C/bBVQ9IFeXqjEdpuIxmKvSkqalE.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Alchemist"
+
+									>Alchemist</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/m/1kMI2v_KEVgo30RFvdFCyySkFo.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Culinarian"
+
+									>Culinarian</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+							</ul>
+						</div>
+						<div class="character__job__role">
+							<h4 class="heading--lead"><img src="https://img.finalfantasyxiv.com/lds/h/c/_pbf8dASjs-lT233ljqfamS52o.png" width="24" height="24" class="character__job__icon__title">Disciples of the Land</h4>
+							<ul class="character__job clearfix">
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/A/aM2Dd6Vo4HW_UGasK7tLuZ6fu4.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Miner"
+
+									>Miner</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/jGRnjIlwWridqM-mIPNew6bhHM.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Botanist"
+
+									>Botanist</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/x/B4Azydbn7Prubxt7OL9p1LZXZ0.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Fisher"
+
+									>Fisher</div>
+									<div class="character__job__exp">- / -</div>
+								</li>
+
+							</ul>
+						</div>
+					</div>
+
+
+
+
+				</div>
+			</div>
+		</div>
+
+		<div class="ldst__side">
+
+
+
+
+			<div class="l__rside__bnr clearfix">
+				<a href="https://forum.square-enix.com/ffxiv/forum.php?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_forum" target="_blank" class="l__rside__bnr--forums"><img src="https://img.finalfantasyxiv.com/lds/h/i/i3r6u3moBzQFfijSTu9k3EJirQ.png" width="100" height="62" alt="Forums"></a><a href="https://sqex.to/Msp?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_mogstation" target="_blank" class="l__rside__bnr--mog_station"><img src="https://img.finalfantasyxiv.com/lds/h/3/GjsnqfVxPQrE4Jve8GvKZABF5w.png" width="100" height="62" alt="Mog Station"></a><a href="/pr/blog/?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_officalblog" target="_blank" class="l__rside__bnr--blog"><img src="https://img.finalfantasyxiv.com/lds/h/d/nVeXvIIStLv3npokivV0EzkKwI.png" width="100" height="62" alt="Official Blog"></a>
+			</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+			<div class="mb10"><a href="/endwalker/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_endwalker"><img src="https://img.finalfantasyxiv.com/lds/banner/998/v60_211207_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="https://store.finalfantasyxiv.com/ffxivstore/en-gb/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_onlinestore" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/banner/916/LDS_ffxivos_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/special/2022/All_Saints_Wake/rjk7wevhuy?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_all_saints_wake"><img src="https://img.finalfantasyxiv.com/lds/banner/1119/mnbn_all_saints_wake-1_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/community_finder/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_cf202112"><img src="https://img.finalfantasyxiv.com/lds/banner/1104/LDS_CF_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/jobguide/battle/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_jobguide"><img src="https://img.finalfantasyxiv.com/lds/banner/1089/jobguide_v60_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/uiguide/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_uiguide"><img src="https://img.finalfantasyxiv.com/lds/banner/671/pc_uiguide_eu.jpg"></a></div>
+
+
+
+			<div class="conducting_area">
+
+				<img src="https://img.finalfantasyxiv.com/lds/h/z/EhLfs3eya3Aidfr8A6PbXOBgtA.png" width="300" height="218" alt="">
+
+				<div class="inr">
+					<a href="
+				http://freetrial.finalfantasyxiv.com/" class="bt_conducting">
+						<img src="https://img.finalfantasyxiv.com/lds/h/s/3KRua4vzZJvRXn0IMk8Da103bw.png" width="284" height="80" alt="Start Your Free Trial">
+					</a>
+					<a href="/product/?utm_source=lodestone&utm_medium=pc_buyarea&utm_campaign=eu_buynow" class="bt_conducting" target="_blank">
+						<img src="https://img.finalfantasyxiv.com/lds/h/p/to8CzK_gktAHpLuSGzCkNdLfWo.png" width="284" height="80" alt="BUY NOW!">
+					</a>			<a href="https://support.eu.square-enix.com/faqarticle.php?id=5383&la=2&kid=78775" onmousedown="ga('send', 'event', 'lodestone_eu', 'howtoupgrade_link', 'EU-lodestone-UG_20170620', true);" class="bt_ft_migration">			<img src="https://img.finalfantasyxiv.com/lds/h/0/5rrJdYAcP3if6zX6d62dHV3t34.png" width="260" height="80" alt="Upgrade Your Free Trial<br />to the Full Version">
+				</a>
+				</div>
+			</div>
+
+
+
+
+
+
+
+
+
+			<div class="mb10"><a href="/tales_of_adventure/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_tales_of_adventure"><img src="https://img.finalfantasyxiv.com/lds/banner/1079/LDS_Tales_of_Adventure_v60_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/special/friend_recruit/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_friendrecruit"><img src="https://img.finalfantasyxiv.com/lds/banner/203/bn_Recruit_a_Friend_eu.png"></a></div>
+
+
+
+
+
+
+			<div class="ldst__side__box">
+
+
+
+				<div class="heading--side">
+					<h3>Community Wall</h3>
+					<a href="/lodestone/community/" class="heading--side__icon icon-list__side js__tooltip" data-tooltip="See More"></a>
+				</div>
+				<div class="heading__icon parts__space--reset js__toggle_wrapper">
+					<h4>Recent Activity</h4>
+					<i class="icon-btn__filter js__toggle_trigger js__tooltip" data-tooltip="Filter"></i>
+					<div class="parts__switch parts__switch--filter js__toggle_item">
+						<p class="parts__text">
+							Filter which items are to be displayed below.<br>
+							<span class="parts__text__notes">
+				* Notifications for standings updates are shared across all Worlds.<br>
+				* Notifications for PvP team formations are shared for all languages.<br>
+				* Notifications for free company formations are shared for all languages.
+			</span>
+						</p>
+
+
+						<div class="form__horizontal js__communitywall_filter">
+							<input type="hidden" name="order" value=""><h5 class="heading--side--lead">Sort by</h5><ul class="form__row parts__spce--8"><li><input type="checkbox" name="community_type" value="blog" class="form__checkbox" id="community_type01"><label class="form__checkbox__label" for="community_type01">Blog</label></li><li><input type="checkbox" name="community_type" value="event" class="form__checkbox" id="community_type02"><label class="form__checkbox__label" for="community_type02">Event & Party Recruitment</label></li><li><input type="checkbox" name="community_type" value="fc" class="form__checkbox" id="community_type03"><label class="form__checkbox__label" for="community_type03">Free Company</label></li><li><input type="checkbox" name="community_type" value="db" class="form__checkbox" id="community_type04"><label class="form__checkbox__label" for="community_type04">Eorzea Database</label></li><li><input type="checkbox" name="community_type" value="ranking" class="form__checkbox" id="community_type05"><label class="form__checkbox__label" for="community_type05">Standings</label></li><li><input type="checkbox" name="community_type" value="pvpteam" class="form__checkbox" id="community_type06"><label class="form__checkbox__label" for="community_type06">PvP Team</label></li><li><input type="checkbox" name="community_type" value="community_finder" class="form__checkbox" id="community_type07"><label class="form__checkbox__label" for="community_type07">Community Finder</label></li></ul><h5 class="heading--side--lead">Data Center / Home World</h5><div class="select-pulldown"><label class="control-label" for="world"></label><select name="community_worldname" class="select-pulldown__open"><option value="">Select All</option><optgroup label="Data Center"><option value="_dc_Elemental">Elemental</option><option value="_dc_Gaia">Gaia</option><option value="_dc_Mana">Mana</option><option value="_dc_Aether">Aether</option><option value="_dc_Primal">Primal</option><option value="_dc_Crystal">Crystal</option><option value="_dc_Chaos">Chaos</option><option value="_dc_Light">Light</option></optgroup><optgroup label="Home World"><option value="Adamantoise">Adamantoise</option><option value="Aegis">Aegis</option><option value="Alexander">Alexander</option><option value="Anima">Anima</option><option value="Asura">Asura</option><option value="Atomos">Atomos</option><option value="Bahamut">Bahamut</option><option value="Balmung">Balmung</option><option value="Behemoth">Behemoth</option><option value="Belias">Belias</option><option value="Brynhildr">Brynhildr</option><option value="Cactuar">Cactuar</option><option value="Carbuncle">Carbuncle</option><option value="Cerberus">Cerberus</option><option value="Chocobo">Chocobo</option><option value="Coeurl">Coeurl</option><option value="Diabolos">Diabolos</option><option value="Durandal">Durandal</option><option value="Excalibur">Excalibur</option><option value="Exodus">Exodus</option><option value="Faerie">Faerie</option><option value="Famfrit">Famfrit</option><option value="Fenrir">Fenrir</option><option value="Garuda">Garuda</option><option value="Gilgamesh">Gilgamesh</option><option value="Goblin">Goblin</option><option value="Gungnir">Gungnir</option><option value="Hades">Hades</option><option value="Hyperion">Hyperion</option><option value="Ifrit">Ifrit</option><option value="Ixion">Ixion</option><option value="Jenova">Jenova</option><option value="Kujata">Kujata</option><option value="Lamia">Lamia</option><option value="Leviathan">Leviathan</option><option value="Lich">Lich</option><option value="Louisoix">Louisoix</option><option value="Malboro">Malboro</option><option value="Mandragora">Mandragora</option><option value="Masamune">Masamune</option><option value="Mateus">Mateus</option><option value="Midgardsormr">Midgardsormr</option><option value="Moogle">Moogle</option><option value="Odin">Odin</option><option value="Omega">Omega</option><option value="Pandaemonium">Pandaemonium</option><option value="Phoenix">Phoenix</option><option value="Ragnarok">Ragnarok</option><option value="Ramuh">Ramuh</option><option value="Ridill">Ridill</option><option value="Sargatanas">Sargatanas</option><option value="Shinryu">Shinryu</option><option value="Shiva">Shiva</option><option value="Siren">Siren</option><option value="Spriggan">Spriggan</option><option value="Tiamat">Tiamat</option><option value="Titan">Titan</option><option value="Tonberry">Tonberry</option><option value="Twintania">Twintania</option><option value="Typhon">Typhon</option><option value="Ultima">Ultima</option><option value="Ultros">Ultros</option><option value="Unicorn">Unicorn</option><option value="Valefor">Valefor</option><option value="Yojimbo">Yojimbo</option><option value="Zalera">Zalera</option><option value="Zeromus">Zeromus</option><option value="Zodiark">Zodiark</option></optgroup></select></div><h5 class="heading--side--lead">Primary language</h5><div class="select-pulldown"><label class="control-label" for="lang"></label><select name="community_lang" class="select-pulldown__open"><option value="">Select All</option><option value="ja">Japanese</option><option value="en">English</option><option value="de">German</option><option value="fr">French</option></select></div><h5 class="heading--side--lead">Displaying</h5><div class="select-pulldown"><label class="control-label" for="limit"></label><select name="community_limit" class="select-pulldown__open"><option value="10">10</option><option value="20">20</option><option value="30">30</option></select></div><div class="form__submit form__submit--full"><input type="submit" value="Filter" class="js__bt_communitywall_filter"></div>
+						</div>
+
+
+					</div>
+				</div>
+
+
+				<ul class="side__list__box">
+
+
+					<div class="entry more_"><a href="/lodestone/character/41152333/blog/4942275/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-6d51277c3dd" class="datetime_dynamic_ymdhm" data-epoch="1642767743">-</span><script>document.getElementById('datetime-6d51277c3dd').innerHTML = ldst_strftime_dynamic_ymdhm(1642767743);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">End Walker-z</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Alexander&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>End Walker-z (<i class="xiv-lds xiv-lds-home-world"></i>Alexander) posted a new blog entry, "蒼天のおじさん　奮闘記2(バハムートはシャキらない2)."</p></div></div></div></a><a href="/lodestone/character/41152333/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/90c165911669f6760685a0df99c269ee_b7a71d8799cf6dd75b711a7f52de6675fc0_96x96.jpg?1642767078" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/40644630/blog/4942274/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-af158906b65" class="datetime_dynamic_ymdhm" data-epoch="1642767639">-</span><script>document.getElementById('datetime-af158906b65').innerHTML = ldst_strftime_dynamic_ymdhm(1642767639);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Bibi Tunbas</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Mandragora&nbsp;(Mana)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Bibi Tunbas (<i class="xiv-lds xiv-lds-home-world"></i>Mandragora) posted a new blog entry, "サ、サ、サ、サベネアァァァ〜〜〜〜！！！！."</p></div></div></div></a><a href="/lodestone/character/40644630/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/8c41ec432f747f1e95da1f55c3d8d1a3_ee738654add55c3d07ea92d8e108074cfc0_96x96.jpg?1642766986" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/26422021/blog/4942272/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-ebb81bc0971" class="datetime_dynamic_ymdhm" data-epoch="1642767626">-</span><script>document.getElementById('datetime-ebb81bc0971').innerHTML = ldst_strftime_dynamic_ymdhm(1642767626);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Tanaty Miston</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Gungnir&nbsp;(Elemental)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Tanaty Miston (<i class="xiv-lds xiv-lds-home-world"></i>Gungnir) posted a new blog entry, "【日記】地図ツアー今月もやります."</p></div></div></div></a><a href="/lodestone/character/26422021/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/19ea06334ab9a5ca736793ee1babbf43_8f82f937943b6baf4c565020d5eba0ccfc0_96x96.jpg?1642767565" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/22869886/blog/4942271/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-d45fba54ebc" class="datetime_dynamic_ymdhm" data-epoch="1642767549">-</span><script>document.getElementById('datetime-d45fba54ebc').innerHTML = ldst_strftime_dynamic_ymdhm(1642767549);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Yakkuru Imu</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Atomos&nbsp;(Elemental)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Yakkuru Imu (<i class="xiv-lds xiv-lds-home-world"></i>Atomos) posted a new blog entry, "恐怖！音が鳴ったら順番にマクロ押すだけ士."</p></div></div></div></a><a href="/lodestone/character/22869886/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/6522ae817557ddb610a62c3af73aab92_cf768a751b1f5e355c2fd39a9ed91f3ffc0_96x96.jpg?1642766657" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/35811278/blog/4941646/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-17f3ced09a4" class="datetime_dynamic_ymdhm" data-epoch="1642767549">-</span><script>document.getElementById('datetime-17f3ced09a4').innerHTML = ldst_strftime_dynamic_ymdhm(1642767549);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Malu Design</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Zeromus&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Malu Design (<i class="xiv-lds xiv-lds-home-world"></i>Zeromus) posted a new blog entry, "初めてイベント募集してみた----からのお礼."</p></div></div></div></a><a href="/lodestone/character/35811278/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/3b626fe0af2a05cb78cdf262b187d00d_c76848359d0b4d2f37aefbb9903ed97bfc0_96x96.jpg?1642765110" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/19045024/blog/4942270/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-199c5f4e518" class="datetime_dynamic_ymdhm" data-epoch="1642767360">-</span><script>document.getElementById('datetime-199c5f4e518').innerHTML = ldst_strftime_dynamic_ymdhm(1642767360);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Cheesecake Danish</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ifrit&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Cheesecake Danish (<i class="xiv-lds xiv-lds-home-world"></i>Ifrit) posted a new blog entry, "準備不足の特殊FATE、そして、守護天節."</p></div></div></div></a><a href="/lodestone/character/19045024/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/8cf976f182290f8eb112dea3de39f903_f9f796348bc43067c7242ec4551cde69fc0_96x96.jpg?1642764420" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/39466622/blog/4942269/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-d05dca07a53" class="datetime_dynamic_ymdhm" data-epoch="1642767322">-</span><script>document.getElementById('datetime-d05dca07a53').innerHTML = ldst_strftime_dynamic_ymdhm(1642767322);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Lilina Shinonome</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ixion&nbsp;(Mana)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Lilina Shinonome (<i class="xiv-lds xiv-lds-home-world"></i>Ixion) posted a new blog entry, "わかってはいるんだけどね・・・."</p></div></div></div></a><a href="/lodestone/character/39466622/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/854d3c933801b806bcc3de04a51267ae_7126768d768f6c6c7fed3eaee98c3a8afc0_96x96.jpg?1642764300" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/23073189/blog/4942266/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-bdd1473a702" class="datetime_dynamic_ymdhm" data-epoch="1642767082">-</span><script>document.getElementById('datetime-bdd1473a702').innerHTML = ldst_strftime_dynamic_ymdhm(1642767082);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Pon Rookie</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ifrit&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Pon Rookie (<i class="xiv-lds xiv-lds-home-world"></i>Ifrit) posted a new blog entry, "【ポンデの日常風景】メンバーが釣ってきた「ヌシ」がFCハウスに！の巻."</p></div></div></div></a><a href="/lodestone/character/23073189/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/c858102927ab63ede56d07b2f280210d_f9f796348bc43067c7242ec4551cde69fc0_96x96.jpg?1642764634" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/freecompany/9230127436295964601/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header--common clearfix"><time class="entry__activity__time"><span id="datetime-3ec43b8b5f7" class="datetime_dynamic_ymdhm" data-epoch="1642767075">-</span><script>document.getElementById('datetime-3ec43b8b5f7').innerHTML = ldst_strftime_dynamic_ymdhm(1642767075);</script></time></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__fc js__tooltip"data-tooltip="Free Company"></span></div><div class="entry__activity__txt--message"><p>Enjoy Club F (Ixion) has been formed.</p></div></div></div></a><div class="entry__activity__link"><img src="https://img.finalfantasyxiv.com/lds/h/9/_Huf58epDlt9vXiO8IIfPXxtXI.png" width="50" height="50" alt=""></div></div>
+
+
+					<div data-min_id="4838379482" class="entry more_"data-has_next=""><a href="/lodestone/character/18833809/blog/4941298/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-e6bd247ebd4" class="datetime_dynamic_ymdhm" data-epoch="1642767053">-</span><script>document.getElementById('datetime-e6bd247ebd4').innerHTML = ldst_strftime_dynamic_ymdhm(1642767053);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Killy Toa</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Valefor&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Killy Toa (<i class="xiv-lds xiv-lds-home-world"></i>Valefor) posted a new blog entry, "出来立ておにぎり美味しいです！."</p></div></div></div></a><a href="/lodestone/character/18833809/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/d78c2cdd2b79ef7d6c7af3a6f5daf8ff_485f4777c38002871591fb54f27edc65fc0_96x96.jpg?1642764923" width="40" height="40" alt=""></div></a></div>
+
+
+
+
+				</ul>
+
+
+			</div>
+
+
+
+			<div class="ldst__side__box">
+
+
+
+
+				<div class="heading--side">
+					<h3>Standings</h3>
+					<a href="/lodestone/ranking/" class="heading--side__icon icon-list__side js__tooltip" data-tooltip="See More"></a>
+				</div>
+
+
+				<h4 class="heading--side--sm">The Feast Rankings</h4>
+
+				<a href="/lodestone/ranking/thefeast/result/" class="entry__ranking__thefeast">
+					Pre-season is under way!<br>
+					View results of the previous season
+				</a>
+
+
+
+
+				<h4 class="heading--side--sm">Grand Company Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Luke Breitner</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Fenrir&nbsp;(Gaia)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/9658201/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/bb7875f35a390ed9493dfde91c4d0039_d384cf5ad7db803f29799f36ebbc3eadfc0_96x96.jpg?1642766294" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Kiryuin Satsuki</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/7250925/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/ba64ef52323ad0c23edaa3bafc9f4e82_58a84e851e55175d22158ca97af58a1ffc0_96x96.jpg?1642764909" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Ari Nuovo</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Phoenix&nbsp;(Light)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/19970354/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/1eb1b6c06bbadecb3c0f3b8cbb1b07e0_5047bc596a4bab2dc7f7c120bb22dec5fc0_96x96.jpg?1642766146" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+				</ul>
+
+
+
+				<h4 class="heading--side--sm">Free Company Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">brotherhood</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Moogle&nbsp;(Chaos)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9233364398528115650/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/F00_f4d64b4d75ce7d3be3ba37e24ccc7830_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S01_49d2902352dde56ae3c6423a937ac151_00_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">The Syndicate</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9231394073691073564/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/B08_de875598ba3f5ef9fe02858d29c85455_33_40x40.png" width="40" height="40">
+
+							<img src="https://img2.finalfantasyxiv.com/c/F1e_ed8a164ee0086dc3e36d078e76126110_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S5c_c48179b4e96cff6ed7c51da16ca90c11_04_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">CatOfHeart</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Masamune&nbsp;(Mana)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9236882835737003825/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/B0f_8c3fc97865a1c6bfa360c1bce22b9fa0_c0_40x40.png" width="40" height="40">
+
+							<img src="https://img2.finalfantasyxiv.com/c/F04_1223707ec2cfc1bde4ba8f0f85a74b24_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S33_f0483d3975a483769f674866ff99675e_01_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+				</ul>
+
+
+
+				<h4 class="heading--side--sm">Frontline Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Pharis Bloodborne</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ragnarok&nbsp;(Chaos)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/7338237/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/553c62b150030202afb4206e6f758b91_40d57ba713628f3f1ef5ef204b6d76d2fc0_96x96.jpg?1642767663" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Ni Xi</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Malboro&nbsp;(Crystal)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/34789289/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/356072546b70540163fcdc5bf3f1a6f3_2e97c13fdd593d15d543093f8a37b6f0fc0_96x96.jpg?1642766469" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Blueberry Lollipop</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/39019280/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/2be5c15e35dbd1670f814874fff1234b_58a84e851e55175d22158ca97af58a1ffc0_96x96.jpg?1642767672" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Jo Se</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Sargatanas&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/36466361/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/c9e98a67d1423c12fa7b4c38a41e80e0_ba22853447012a24cee115315d6a5bebfc0_96x96.jpg?1642767272" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Kayeson Mon&#39;roux</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Leviathan&nbsp;(Primal)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/36261740/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/f44e37565c9e753a163ffc1a0d5105ea_a91aae52cff9ef65932db06b150ffd47fc0_96x96.jpg?1642766011" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+				</ul>
+
+
+			</div>
+
+
+
+
+
+
+
+
+
+
+		</div>
+
+	</div>
+
+</div>
+
+
+
+<div id="link_spsite" class="link_sp-site"><a href="javascript:void(0)">Mobile Version</a><br></div><footer class="l__footer l__footer__eu"><div class="page-top"><span class="page-top__btn"></span></div><div class="l__footer__inner"><div class="l__footer__logo"><img src="https://img.finalfantasyxiv.com/lds/h/L/EbtcXqPUGzsVYdi23FpUR25oH4.png" width="320" height="32" alt=""></div><p class="l__footer__officiel">Official Information</p><ul class="l__footer__sns"><li><a href="https://www.facebook.com/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-facebook xiv-lds-3x"></i><span>Facebook</span></a></li><li class="l__footer__sns--twitter"><a href="https://twitter.com/ff_xiv_en" target="_blank"><i class="xiv-lds xiv-lds-twitter xiv-lds-3x"></i>Twitter</a> / <a href="https://twitter.com/FFXIV_NEWS_EN" target="_blank">Twitter News</a></li><li><a href="http://www.youtube.com/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-youtube xiv-lds-3x"></i><span>Official Channel</span></a></li><li><a href="https://www.instagram.com/ffxiv/" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-instagram xiv-lds-3x"></i><span>Instagram</span></a></li><li><a href="https://www.twitch.tv/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-twitch xiv-lds-3x"></i><span>Twitch</span></a></li></ul><ul class="l__footer__link-list"><li class="link_license" id="link_license"><a href="/license/" target="_blank">License</a></li><li><a href="https://support.eu.square-enix.com/rule.php?id=5383&la=2" target="_blank">Rules & Policies</a></li><li><a href="https://square-enix-games.com/en_GB/documents/privacy" target="_blank">Privacy Policy</a></li><li><a href="https://square-enix-games.com/en_GB/documents/cookies" target="_blank">Cookie Policy</a></li></ul></div><div class="l__footer__legal-area"><div class="l__footer__legal-area__inner clearfix"><div class="l__footer__legal-area__box"><ul class="l__footer__legal-area__bnr-list"><li><a href="http://www.pegi.info" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/h/8/bLhWLeqRDavUCuBhK8X0yB9bKA.png" width="41" height="50" alt="PEGI"></a></li><li><img src="https://img.finalfantasyxiv.com/lds/h/D/egrXwtjrQC8nFGhA1rWb0PO8R0.png" width="245" height="39" alt="PlayStation PS5 PS4"></li><li><img src="https://img.finalfantasyxiv.com/lds/h/E/38lyWv84H59UEwldgCOGU2B9dM.png" width="33" height="39" alt="PC"></li><li><img src="https://img.finalfantasyxiv.com/lds/h/v/hyXqlwktN4v0EssRTzkbMf_7OQ.png" width="30" height="39" alt="Mac"></li><li class="last"><img src="https://img.finalfantasyxiv.com/lds/h/U/15QxPO___EcPlhMI9ydNRRxEY8.png" width="90" height="39" alt="STEAM"></li></ul><p class="l__footer__legal-area__text">“<i class="ps"></i>”, “PlayStation”, “<i class="ps5"></i>” and “<i class="ps4"></i>” are registered trademarks or trademarks of Sony Interactive Entertainment Inc.<br />Mac is a trademark of Apple Inc.<br />©2021 Valve Corporation. Steam and the Steam logo are trademarks and/or registered trademarks of Valve Corporation in the U.S. and/or other countries.</p></div><div class="l__footer__legal-area__box"><p class="l__footer__legal-area__copyright">© 2010 - 2022 <a href="https://square-enix-games.com/en_GB" target="_blank">SQUARE ENIX</a> CO., LTD. All Rights Reserved.<br>ENDWALKER, SHADOWBRINGERS, STORMBLOOD, HEAVENSWARD and A REALM REBORN are registered trademarks or trademarks of Square Enix Co., Ltd.<br />FINAL FANTASY, FINAL FANTASY XIV, FFXIV, SQUARE ENIX and the SQUARE ENIX logo are registered trademarks or trademarks of Square Enix Holdings Co., Ltd.<br>LOGO ILLUSTRATION: © 2010, 2014, 2016, 2018, 2021 YOSHITAKA AMANO</p></div></div></div></footer>
+
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-43364669-4"></script>
+<script>
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+
+	(function() {
+		var gtag_config = {
+			'link_attribution': true,
+			'custom_map': {
+				'dimension1': 'login',
+				'dimension2': 'theme',
+				'dimension3': 'mychara',
+				'dimension4': 'character_link'
+			},
+			'login': 'notloginuser',
+			'theme':  'white',
+		};
+
+
+		gtag('js', new Date());
+
+		gtag('config', 'UA-43364669-4', gtag_config);
+		gtag('config', 'UA-43364669-1', gtag_config);
+	})();
+</script>
+
+
+
+
+<script src="https://img.finalfantasyxiv.com/lds/pc/en-gb/js/i18n.js?1642399092"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/i/2ur_0e4qXk_NwNv0bGjrUHThCM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/g/uQNBgvCaabd4gw5kMpaT-psp1Q.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/b/RKD_bGx738E81TyiPQN4kGf-_Y.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/Z/wqo4GxX1wALdnxx6xOv38NxFVY.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/e/TSPHxkEhdcyaPMm0rpoBtk1dZA.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/P/O9-IKBqOphhkhVvm2QPrR9x5p4.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/9/TTeYt1mN0BF3R1Av3fWlknchv4.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/8/b_tPmOnEw1tyr2dp2InkGxUlMA.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/Y/6WaukM6m3WFE2JXrCEb6tsknik.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/E/ImNUSWkI-O9dQP5ADa41RiGxGY.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/t/kQLYFR8rOESAOiyT9o2PsRnLq0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/C/q1cplyit_St5sY1BUgBKFuLapM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/s/Gt4XmT3a3nu52yKZPoVWcvrfFM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/A/LATlIIBarKmGFTTVid87k_GPFg.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/W/r-0ziwRwdsVj1lEyFHfmVyFgKw.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/piXyeCeUEtNAzCIq6jXoqNimzE.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/t/85HyWVlETnECMXo9l40HahjdO0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/OIfkF0BnyASNQ0RswButWbIKCU.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/U/jhEwPt7MvJy47-ExjjZ3lHW3qI.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/0/f52zA7ACWvjEMB1oWe8kfyGWH0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/l/-_ePiHXNE_1t8LnRcmRAbhRME8.js"></script>
+<script src="https://www.youtube.com/iframe_api"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/P/MYGDtxveSuUwuhprm8oj1Hhuq8.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/it7tc9wvjlJJstEQUNjiModhdM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/n/HMQm8_JEoqrSmuv5RmmKgTldGc.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/B/ElvNJhxzt4ULBYHMPrt3JiAKGU.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/d/UfPsCOe_Nl7ytqem4KWdsftkY0.js"></script>
+
+
+<div id="dialog_bg" style="opacity:0; visibility: hidden;"></div>
+<!-- dialog -->
+<div name="ldstDialog" class="overlay__area js__overlay" style="opacity:0; visibility: hidden; top: 0px">
+	<p class="overlay__text--icon"></p>
+
+	<div class="outbound_consent hide">
+		<input type="checkbox" name="outbound_consent" value="1" id="outbound_consent" class="form__checkbox">
+		<label for="outbound_consent" class="form__checkbox__label form__outbound">
+			Do not show this message again.
+		</label>
+	</div>
+
+	<!-- SIMPLE DIALOG -->
+	<a href="javascript:void(0);" class="js__dialog_btn btn__color--radius js__overlay_ok">Confirm</a>
+	<!-- //SIMPLE DIALOG -->
+	<!-- CONFIRM DIALOG -->
+	<ul class="js__dialog_btn overlay__btn js__overlay_btn">
+		<li><a href="javascript:void(0);" class="js__overlay_yes">Yes</a></li>
+		<li><a href="javascript:void(0);" class="js__overlay_no">No</a></li>
+	</ul>
+	<!-- //CONFIRM DIALOG -->
+</div>
+<!-- //dialog -->
+
+
+
+
+</body>
+</html>

--- a/src/test/resources/data/lodestone/Character-33000046-Minions.html
+++ b/src/test/resources/data/lodestone/Character-33000046-Minions.html
@@ -1,0 +1,1320 @@
+<!DOCTYPE html>
+<html lang="en-gb" class="en-gb" xmlns:og="http://ogp.me/ns#" xmlns:fb="http://www.facebook.com/2008/fbml">
+<head><meta charset="utf-8">
+
+	<!-- Google Tag Manager -->
+	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	})(window,document,'script','digitalData','GTM-P37XSWJ');</script>
+	<!-- End Google Tag Manager -->
+
+	<title>K&#39;ewl D&#39;eeps | FINAL FANTASY XIV, The Lodestone</title>
+	<meta name="description" content="Character profile for K&#39;ewl D&#39;eeps.">
+	<meta name="keywords" content="FF14,FFXIV,Final Fantasy XIV,Final Fantasy 14,Lodestone,players' site,community site,A Realm Reborn,Heavensward,Stormblood,Shadowbringers,Endwalker,MMO">
+	<meta name="author" content="SQUARE ENIX Ltd.">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="format-detection" content="telephone=no">
+
+	<link rel="shortcut icon" type="image/vnd.microsoft.icon" href="https://img.finalfantasyxiv.com/lds/pc/global/images/favicon.ico?1490749553">
+	<link rel="apple-touch-icon-precomposed" href="https://img.finalfantasyxiv.com/lds/h/0/U2uGfVX4GdZgU1jASO0m9h_xLg.png">
+	<meta name="msapplication-TileImage" content="https://img.finalfantasyxiv.com/lds/h/0/U2uGfVX4GdZgU1jASO0m9h_xLg.png">
+
+	<meta name="msapplication-TileColor" content="#000000">
+	<link rel="alternate" hreflang="ja" href="https://jp.finalfantasyxiv.com/lodestone/character/33000046/minion/">
+	<link rel="alternate" hreflang="en-us" href="https://na.finalfantasyxiv.com/lodestone/character/33000046/minion/">
+	<link rel="alternate" hreflang="fr" href="https://fr.finalfantasyxiv.com/lodestone/character/33000046/minion/">
+	<link rel="alternate" hreflang="de" href="https://de.finalfantasyxiv.com/lodestone/character/33000046/minion/">
+
+
+	<meta name="google-site-verification" content="WwpBRGfcVWgP_LxTs8PHc6EcDM8eCt8Zqck1MAnVmZM">
+
+
+
+
+	<!--[if lt IE 9]>
+	<script src="https://img.finalfantasyxiv.com/lds/h/I/SMlNRnAvuilc1lYKBpzKWpmADs.js"></script>
+
+	<![endif]-->
+	<!-- ** CSS ** -->
+	<link href="https://img.finalfantasyxiv.com/lds/h/M/0kxkkawCCBg1ArBrU_c1cydINM.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/-/tUrZCLFtMgzaHil2OXxbmdw2a0.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/l/6D7j33OWZQd8eVk8IKWT15deH8.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/j/JgAulXN0McN_xRNcKLLbnNh4fs.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/F/wZHqGlYFe-0or10VJJtARsKyko.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/a/bmAvctt6TxsMwvFeI4NiKcWnZM.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/Q/mAASajjDE39sDOGkuOPDZPBt0s.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/w/YgRYdK0dq3N9UCU6nR-7J5PftA.css" rel="stylesheet">
+
+	<link href="https://img.finalfantasyxiv.com/lds/h/b/tInX1HM2lXTimf4ts8i-7wWr1Y.css" rel="stylesheet">
+
+	<link href="https://img.finalfantasyxiv.com/lds/h/w/cuKVxIZUo5Tf3xQ8a9_mn8jZDU.css" rel="stylesheet"
+		  class="sys_theme_css"
+
+		  data-theme_white="https://img.finalfantasyxiv.com/lds/h/w/cuKVxIZUo5Tf3xQ8a9_mn8jZDU.css"
+
+		  data-theme_black="https://img.finalfantasyxiv.com/lds/h/o/q3zLnccpt9t--buuJJqeuTpzOY.css"
+
+	>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<!-- ogp -->
+	<meta property="fb:app_id" content="1400886233468625">
+	<meta property="og:type" content="website">
+	<meta property="og:description" content="Character profile for K&#39;ewl D&#39;eeps.">
+	<meta property="og:title" content="K&#39;ewl D&#39;eeps | FINAL FANTASY XIV, The Lodestone">
+	<meta property="og:url" content="https://eu.finalfantasyxiv.com/lodestone/character/33000046/minion/">
+	<meta property="og:site_name" content="FINAL FANTASY XIV, The Lodestone">
+	<meta property="og:locale" content="en_GB">
+
+	<meta property="og:image" content="https://img.finalfantasyxiv.com/lds/h/I/cy_FoBlOdFg3kBAQdaAxT19pTw.png">
+
+
+
+	<meta property="fb:pages" content="116214575870">
+
+
+	<meta name="twitter:card" content="summary_large_image">
+
+	<meta name="twitter:site" content="@ff_xiv_en">
+
+
+
+
+	<script>
+		var base_domain = 'finalfantasyxiv.com';
+		var ldst_subdomain = 'eu';
+		var strftime_fmt = {
+			'dateHHMM_now': 'Today %H:%M',
+			'dateYMDHMS': '%d/%m/%Y %H:%M:%S',
+			'dateYMDHM': '%d/%m/%Y %H:%M',
+			'dateYMDHM_jp': '%Y/%m/%d %H:%M',
+			'dateHM': '%H:%M',
+			'dateYMDH': '%d/%m/%Y %H',
+			'dateYMD': '%d/%m/%Y',
+			'dateEternal': '%d.%m.%Y',
+			'dateYMDW': '%d/%m/%Y (%a)',
+			'dateHM': '%H:%M',
+			'week.0': 'Sun.',
+			'week.1': 'Mon.',
+			'week.2': 'Tue.',
+			'week.3': 'Wed.',
+			'week.4': 'Thu.',
+			'week.5': 'Fri.',
+			'week.6': 'Sat.'
+		};
+		var base_uri   = '/lodestone/';
+		var api_uri    = '/lodestone/api/';
+		var static_uri = 'https://img.finalfantasyxiv.com/lds/';
+		var subdomain  = 'eu';
+		var csrf_token = 'b726b2475aab6e2b29c16ddcf48f50e5e7d76211';
+		var cis_origin = 'https://secure.square\u002denix.com';
+		var ldst_max_image_size = 31457280;
+		var eorzeadb = {
+			cdn_prefix: 'https://img.finalfantasyxiv.com/lds/',
+			version: '1641278251',
+			version_js_uri:  'https://img.finalfantasyxiv.com/lds/pc/global/js/eorzeadb/version.js',
+			dynamic_tooltip: false
+		};
+		var cookie_suffix = '';
+		var ldst_is_loggedin = false;
+		var show_achievement = false;
+	</script>
+	<script src="https://img.finalfantasyxiv.com/lds/h/A/PknAmzDJUZCNhTGtSGGMIGi5k4.js"></script>
+	<script src="https://img.finalfantasyxiv.com/lds/h/H/hBuD3_ZXTqwHX64YYCchtvgGSs.js"></script>
+
+
+
+
+
+
+
+
+
+</head>
+<body id="community" class=" lang_eu">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P37XSWJ"
+				  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+
+
+
+<div class="brand"><div class="brand__section">
+	<div class="brand__logo">
+		<a href="
+				https://square-enix-games.com/en_GB
+			" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/h/L/cxcD5kjeM52JRVwrrzIF4dZNe0.png" width="130" height="14" alt="SQUARE ENIX">
+		</a>
+	</div>
+
+
+	<div class="brand__search">
+		<form action="/lodestone/community/search/" class="brand__search__form">
+			<div class="brand__search__focus_bg"></div>
+			<div class="brand__search__base_bg"></div>
+			<input type="text" id="txt_search" class="brand__search--text" name="q" placeholder="Search">
+			<input type="submit" id="bt_search" class="brand__search--btn" value="">
+		</form>
+	</div>
+
+
+
+	<div class="brand__theme sys_theme_switcher">
+		<a href="javascript:void(0);"><i class="brand__theme--white sys_theme active js__tooltip" data-tooltip="Theme (Black)" data-theme="white"></i></a>
+		<a href="javascript:void(0);"><i class="brand__theme--black sys_theme js__tooltip" data-tooltip="Theme (White)" data-theme="black"></i></a>
+	</div>
+
+
+	<div class="brand__lang dropdown_trigger_box">
+		<a href="javascript:void(0);" class="brand__lang__btn brand__lang__en-gb dropdown_trigger">English</a>
+		<ul class="brand__lang__select dropdown">
+
+			<li><a href="https://jp.finalfantasyxiv.com/lodestone/character/33000046/minion/" class="brand__lang__jp">日本語</a></li>
+
+			<li><a href="https://na.finalfantasyxiv.com/lodestone/character/33000046/minion/" class="brand__lang__na">English</a></li>
+
+			<li><a href="https://eu.finalfantasyxiv.com/lodestone/character/33000046/minion/" class="brand__lang__eu">English</a></li>
+
+			<li><a href="https://fr.finalfantasyxiv.com/lodestone/character/33000046/minion/" class="brand__lang__fr">Français</a></li>
+
+			<li><a href="https://de.finalfantasyxiv.com/lodestone/character/33000046/minion/" class="brand__lang__de">Deutsch</a></li>
+
+		</ul>
+	</div>
+
+
+
+	<div class="l__cross_menu eu">
+		<a href="javascript:void(null)" class="ffxiv_pr_cross_menu_button_eu"></a>
+		<script>
+			var ffxiv_pr_cross_menu = {
+				uri_js: '/cross_menu/uri.js'
+			};
+		</script>
+		<script src="https://img.finalfantasyxiv.com/lds/promo/pc/global/menu/loader.js"></script>
+	</div>
+
+</div></div>
+
+
+
+
+<header class="l__header">
+	<div class="l__header__inner l__header__bg_image" style="background-image: url(https://img.finalfantasyxiv.com/lds/banner/1074/headerImage_6_0_eu.jpg);">
+		<a href="/lodestone/" class="l__header__link_top"></a>
+
+
+		<a href="/lodestone/topics/detail/66a742165e9415790247c1a1f7d909abf5becb5c/?utm_source=lodestone&amp;utm_medium=pc_header&amp;utm_campaign=eu_6_0patch" class="l__header__link_management"></a>
+
+
+		<div class="l__header__login clearfix"><a href="/lodestone/account/login/" class="l__header__login__btn">
+			<img src="https://img.finalfantasyxiv.com/lds/h/z/6PLTZ82M99GJ7tKOee1RSwvNrQ.png" width="40" height="40" alt="" class="l__header__login__chara_silhouette">
+			<div class="l__header__login__txt">
+				<p>View Your Character Profile</p>
+				<div>Log In</div>
+			</div>
+		</a></div>
+
+
+	</div>
+</header>
+
+
+
+
+
+
+
+
+
+
+<div class="global-nav">
+	<nav class="main-nav eu">
+		<ul class="main-nav__area main-nav__area__community clearfix ">
+			<li class="main-nav__news main-nav__item">
+				<a href="/lodestone/news/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_news-top');"><span>News</span></a>
+				<nav class="sub-nav">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__news">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__news__icon">
+									<li>
+										<a href="/lodestone/news/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_top');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/8/2GwuzUcvqLa-hgQeLUyd8xarI8.png" width="32" height="32" alt="News">
+											News
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/topics/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_topics');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/5/67ZyAIzQUaYoWBmyvFwNvGmCnQ.png" width="32" height="32" alt="Topics">
+											Topics
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/1" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_notices');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/-/Y5JdwnEWYfyO7OlH27eKIm91Ok.png" width="32" height="32" alt="Notices">
+											Notices
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/2" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_maintenance');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/s/-JfULvMAf26L7AaU1OGaGYwanI.png" width="32" height="32" alt="Maintenance">
+											Maintenance
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/3" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_updates');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/p/HPudyOQcwdv97RBwj3FQC552ps.png" width="32" height="32" alt="Updates">
+											Updates
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/4" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_Status');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/S/-IC2xIQhTl2ymYW7deE1fOII04.png" width="32" height="32" alt="Status">
+											Status
+										</div></a>
+									</li>
+								</ul>
+								<ul class="sub-nav__news__text">
+									<li><a href="/lodestone/special/patchnote_log/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_patch-notes_special-sites');"><div>
+										Patch Notes and Special Sites
+										<span class="update">
+											Updated <span id="datetime-0532255e8c7">-</span><script>document.getElementById('datetime-0532255e8c7').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</div></a></li>
+									<li><a href="/lodestone/special/update_log/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_lodestone-update-notes');"><div>
+										<span class="sub_text">Official Community Site</span>
+										The Lodestone Update Notes
+										<span class="update">
+											Updated <span id="datetime-d1df473ecce">-</span><script>document.getElementById('datetime-d1df473ecce').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</div></a></li>
+									<li><a href="/lodestone/worldstatus/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_server-status');"><div>
+										Server Status
+									</div></a></li>
+								</ul>
+							</div>
+						</div>
+
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__promotion main-nav__item">
+				<a href="/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_begin-ff14-top');"><span>Getting Started</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__promotion">
+							<div class="sub-nav__list__inner">
+								<div class="sub-nav__promotion__inner">
+									<div class="sub-nav__promotion__link">
+										<div class="sub-nav__promotion__top">
+											<a href="/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_pr');"><img src="https://img.finalfantasyxiv.com/lds/h/P/ciPXy1S4-ssQuLQJvEF4JWVm5Q.jpg" width="632" height="140" alt="FINAL FANTASY XIV: A Realm Reborn"></a>
+										</div>
+										<ul class="sub-nav__promotion__page">
+											<li><a href="/benchmark/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_benchmark');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/S/2_8ofX4E90a7pS-p0mjFK_tc_U.png" width="64" height="40" alt="Benchmark">
+												<span>Benchmark</span>
+											</a></li>
+											<li><a href="
+
+													http://freetrial.finalfantasyxiv.com/
+												" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_freetrial');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/c/tWvZpXDc_g6yQd5YKK2k5jhuns.png" width="64" height="40" alt="Free Trial">
+												<span>Free Trial</span>
+											</a></li>
+											<li><a href="/product/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_product');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/m/NCNLGrn3U9M85ky-NscraujvN8.png" width="64" height="40" alt="Product">
+												<span>Product</span>
+											</a></li>
+											<li><a href="/winning/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_awards');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/j/udWU20sWmhYoEsQ_FtrAzVwJ3Q.png" width="64" height="40" alt="Awards and Nominations">
+												<span>Awards and Nominations</span>
+											</a></li>
+										</ul>
+									</div>
+									<div class="sub-nav__promotion__patch_site">
+										<a href="/endwalker/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_latest-expansion');"><span>
+											<img src="https://img.finalfantasyxiv.com/lds/h/f/sLzgsq-NNdSMdqLt6Mby4oROC0.png" width="296" height="232" alt="FINAL FANTASY XIV: Endwalker Special Site">
+										</span></a>
+									</div>
+								</div>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+			</li>
+			<li class="main-nav__playguide main-nav__item">
+				<a href="/lodestone/playguide/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_playguide-top');"><span>Play Guide</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__playguide">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__playguide__list">
+									<li><a href="/lodestone/playguide/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_playguide-top');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/P/Lfl3LVb9KMPa5Ye8yxftZkelbc.png" width="40" height="40" alt="Play Guide<br />Top">
+										<span>Play Guide<br />Top</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#game_playguide" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_game-playguide');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/q/qy4dUGMNkjoyVqPweYMIpOApik.png" width="40" height="40" alt="Gameplay Guide and<br />Beginners' Guide">
+										<span>Gameplay Guide and<br />Beginners' Guide</span>
+										<span class="update">
+											Updated <span id="datetime-6c81bd7c877">-</span><script>document.getElementById('datetime-6c81bd7c877').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/db/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_databese');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/N/OYPWhQVCkovUbVcMMck0O4HABU.png" width="40" height="40" alt="Eorzea Database">
+										<span>Eorzea Database</span>
+										<span class="update">
+											Updated <span id="datetime-7eb2fcbf225">-</span><script>document.getElementById('datetime-7eb2fcbf225').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#content_guide" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_contents-guide');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/W/wlHP1NMpdQHcPKUG-swlv71fhE.png" width="40" height="40" alt="Game Features">
+										<span>Game Features</span>
+										<span class="update">
+											Updated <span id="datetime-023056dbc67">-</span><script>document.getElementById('datetime-023056dbc67').innerHTML = ldst_strftime(1638518400, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#side_storyes" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_side-story');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/Z/1QWgBsVU7ZboWyMZlRjCQcDRJg.png" width="40" height="40" alt="Side Stories<br />and More">
+										<span>Side Stories<br />and More</span>
+										<span class="update">
+											Updated <span id="datetime-11a9699e4d6">-</span><script>document.getElementById('datetime-11a9699e4d6').innerHTML = ldst_strftime(1632470400, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#option_service" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_option-service');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/4fXwcEoJzDEmFRt-tD7PeeKvjE.png" width="40" height="40" alt="Additional Services">
+										<span>Additional Services</span>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__community main-nav__item">
+				<a href="/lodestone/community/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_community-top');"><span>Community</span></a>
+				<nav class="sub-nav">
+					<div class="sub-nav__area">
+
+
+						<div class="sub-nav__list sub-nav__community">
+							<div class="sub-nav__list__inner sub-nav__community__flex">
+								<div class="sub-nav__community__link">
+									<div class="sub-nav__community__top">
+										<div class="sub-nav__community__top__wrapper">
+											<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/q/GiEpnP3oCXluFjrlPlM-mgIbS8.png" width="16" height="16" alt="Community">Community</h2>
+											<ul class="sub-nav__community__list">
+												<li><a href="/lodestone/community/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_community-top');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/i/Sa5YF2-VFf4IJ1cjjFAbPf4GWg.png" width="40" height="40" alt="Community Wall">
+													<span>Community Wall</span>
+												</a></li>
+												<li><a href="/lodestone/blog/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_blog');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/h/6gPbLbzUQ_omC_mdXFUA3zPy7I.png" width="40" height="40" alt="Blog">
+													<span>Blog</span>
+												</a></li>
+											</ul>
+										</div>
+										<div class="sub-nav__community__top__wrapper">
+											<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/d/in_Sbc6SzxLU--Npa7URI-_kdg.png" width="16" height="16" alt="Member Recruitment">Member Recruitment</h2>
+											<ul class="sub-nav__community__list">
+												<li><a href="/lodestone/community_finder/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_community-finder');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/V/kHxwEjpY-Fme83ta8VIfi1kyLU.png" width="40" height="40" alt="Community Finder">
+													<span>Community Finder</span>
+												</a></li>
+												<li><a href="/lodestone/event/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_event-party');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/0/k5jD6-BJZHwKA2CtbNcDYZR6oY.png" width="40" height="40" alt="Event & Party Recruitment">
+													<span>Event & Party Recruitment</span>
+												</a></li>
+											</ul>
+										</div>
+									</div>
+									<div class="sub-nav__community__search">
+										<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/X/uQVT3DEl1xlFWHu3UZU4-RBtVk.png" width="16" height="16" alt="Search">Search</h2>
+										<ul class="sub-nav__community__list sub-nav__community__search__list">
+											<li><a href="/lodestone/character/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_chara-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/5/YcEF3K-5SgqU0BxZtT0D1Zsa2A.png" width="40" height="40" alt="Character Search">
+												<span>Character Search</span>
+											</a></li>
+											<li><a href="/lodestone/linkshell/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_ls-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/b/SPCgcBAk4HvMngGzk6H4MfSINg.png" width="40" height="40" alt="Linkshell Search">
+												<span>Linkshell Search</span>
+											</a></li>
+											<li><a href="/lodestone/crossworld_linkshell/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_cwls-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/L/NUGcPcy-C8jvx6oKgEXgwJ1ePE.png" width="40" height="40" alt="CWLS Search ">
+												<span>CWLS Search </span>
+											</a></li>
+											<li><a href="/lodestone/freecompany/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_fc-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/q/GJ-lsgAtsCCDwCm9te3a5sCjpU.png" width="40" height="40" alt="Free Company Search">
+												<span>Free Company Search</span>
+											</a></li>
+											<li><a href="/lodestone/pvpteam/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_pvp-team-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="PvP Team Search">
+												<span>PvP Team Search</span>
+											</a></li>
+										</ul>
+									</div>
+								</div>
+								<div class="sub-nav__community__side">
+									<div class="sub-nav__community__forum">
+										<ul class="sub-nav__community__forum__list">
+											<li><a href="https://forum.square-enix.com/ffxiv/forum.php" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum');">
+												<div class="forum">
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/r/maZ-sHaqn4PMFANUlbH4GzztFM.png" width="40" height="40" alt="Forums">
+													</i><span>Forums</span>
+												</div>
+											</a></li>
+											<li><a href="https://forum.square-enix.com/ffxiv/search.php?do=getdaily_ll&contenttype=vBForum_Post" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum-new-posts');">
+												<div>
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+													</i><span>New Posts</span>
+												</div>
+											</a></li>
+											<li><a href="
+
+														https://forum.square-enix.com/ffxiv/search.php?do=process&search_type=1&contenttypeid=1&devtrack=1&starteronly=0&showposts=1&childforums=1&forumchoice[]=619
+													" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum-dev-tracker');">
+												<div>
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+													</i><span>Dev Tracker</span>
+												</div>
+											</a></li>
+										</ul>
+									</div>
+									<ul class="sub-nav__community__fankit">
+										<li><a href="/lodestone/special/fankit/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_fankit');">
+											<div>
+												<span>Fan Kit</span>
+												<span class="update">
+													Updated <span id="datetime-109556a0e18">-</span><script>document.getElementById('datetime-109556a0e18').innerHTML = ldst_strftime(1640332800, 'YMD');</script>
+												</span>
+											</div>
+										</a></li>
+									</ul>
+								</div>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__ranking main-nav__item">
+				<a href="/lodestone/ranking/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_ranking-top');"><span>Standings</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__ranking">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__ranking__list">
+									<li><a href="/lodestone/ranking/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_ranking-top');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/E/NtymEFiUJfAh25ffTrADsVFkLQ.png" width="40" height="40" alt="Standings Top">
+										<span>Standings Top</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/thefeast/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_feast');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="The Feast Rankings">
+										<span>The Feast Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/deepdungeon2/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_deepdungeon2');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/_/qP22LgUoAFKDTRayb_TEYu6d7g.png" width="40" height="40" alt="Heaven-on-High Rankings">
+										<span>Heaven-on-High Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/deepdungeon/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_deepdungeon');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/p/op9iPrlMmYgTK3Q6NQKifyQOGA.png" width="40" height="40" alt="Palace of the Dead Rankings">
+										<span>Palace of the Dead Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/frontline/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_frontline');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="Frontline Standings">
+										<span>Frontline Standings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/gc/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_gc');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/o/uRmujlTx4X_5c6wETNxssK1d_4.png" width="40" height="40" alt="Grand Company Standings">
+										<span>Grand Company Standings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/fc/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_fc');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/q/GJ-lsgAtsCCDwCm9te3a5sCjpU.png" width="40" height="40" alt="Free Company Standings">
+										<span>Free Company Standings</span>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__help main-nav__item">
+				<a href="/lodestone/help/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_help-support-top');"><span>Help & Support</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__help">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__help__list">
+									<li><a href="/lodestone/help/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_help-support-top');">
+										<span>Help & Support</span>
+									</a></li>
+									<li><a href="/lodestone/help/about_the_lodestone/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_about-lodestone');">
+										<span>About the Lodestone</span>
+									</a></li>
+									<li><a href="
+
+											https://support.eu.square-enix.com/faq.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_faq');">
+										<span>FAQ</span>
+									</a></li>
+									<li><a href="
+
+											https://eu.square-enix.com/en/seaccount/
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_sqex-account');">
+										<span>Square Enix Account Information</span>
+									</a></li>
+								</ul>
+								<ul class="sub-nav__help__other">
+									<li><a href="
+
+											https://support.eu.square-enix.com/rule.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_rule-policies');">
+										<div>
+											<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+											</i><span>Rules & Policies</span>
+										</div>
+									</a></li>
+									<li><a href="
+
+											https://support.eu.square-enix.com/main.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_customer-service');">
+										<div>
+											<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+											</i><span>Customer Service</span>
+										</div>
+									</a></li>
+									<li><a href="https://sqex.to/Msp" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_mogstation');">
+										<div>
+											<i class="ic_mogst"><img src="https://img.finalfantasyxiv.com/lds/h/S/6IKp0hN6xQqTYPgnPIsd2fjzSI.png" width="32" height="32" alt="">
+											</i><span>Mog Station</span>
+										</div>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+		</ul>
+	</nav>
+</div>
+
+
+
+
+<div class="ldst__bg">
+
+	<div id="breadcrumb">
+		<ul itemscope itemscope itemtype="https://schema.org/BreadcrumbList" class="clearfix">
+			<li class="breadcrumb__home" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/" itemprop="item"><span itemprop="name">HOME</span></a>
+				<meta itemprop="position" content="1" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/community/" itemprop="item" class="breadcrumb__link"><span itemprop="name">Community</span></a>
+				<meta itemprop="position" content="2" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/character/" itemprop="item" class="breadcrumb__link"><span itemprop="name">Character</span></a>
+				<meta itemprop="position" content="3" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<span itemprop="name">K&#39;ewl D&#39;eeps</span>
+				<meta itemprop="position" content="4" />
+			</li>
+
+
+		</ul>
+	</div>
+
+
+	<h1 class="heading__title">Character</h1>
+
+
+
+	<nav class="btn__corner_block">
+		<ul class="btn__corner_block--3">
+
+			<li>
+				<a href="/lodestone/character/33000046/" class="btn__menu btn__menu--active">Profile</a>
+			</li>
+			<li>
+				<a href="/lodestone/character/33000046/blog/" class="btn__menu">Blog</a>
+			</li>
+			<li>
+				<a href="/lodestone/character/33000046/event/" class="btn__menu">Events</a>
+			</li>
+
+		</ul>
+	</nav>
+
+
+
+	<div class="ldst__contents clearfix">
+
+		<div class="ldst__main">
+
+
+
+
+			<div id="character" class="ldst__window">
+				<h2 class="heading--lg">Character</h2>
+
+
+
+				<div class="frame__chara js__toggle_wrapper">
+					<a href="/lodestone/character/33000046/" class="frame__chara__link">
+						<div class="frame__chara__face">
+							<img src="https://img2.finalfantasyxiv.com/f/197341aa090981d3cf179d2703eb85bc_284358f8eb4efc9095914e46798c6ab3fc0_96x96.jpg?1642767359" width="40" height="40" alt="">
+						</div>
+						<div class="frame__chara__box">
+
+							<p class="frame__chara__name">K&#39;ewl D&#39;eeps</p>
+
+							<p class="frame__chara__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Coeurl&nbsp;(Crystal)</p>
+						</div>
+					</a>
+					<div class="parts__connect--state js__toggle_trigger">
+
+
+						<i class="parts__connect_off js__tooltip" data-tooltip="You have no connection with this character."></i>
+
+					</div>
+
+					<div class="parts__switch js__toggle_item">
+
+						<p class="character__connect__text">You have no connection with this character.</p>
+
+
+
+
+
+						<div class="heading--md-slide">Follower Requests</div>
+						<p class="entry__toggle__text">Before this character can be followed, you must first submit a follower request.<br />Do you wish to proceed?</p>
+						<ul class="btn__switch character__connect__form">
+							<li><a href="/lodestone/account/login/">Yes</a></li>
+							<li><a href="javascript:void(0)" class="js__toggle_trigger">No</a></li>
+						</ul>
+
+
+
+					</div>
+
+				</div>
+
+				<ul class="character__profile_tab js__character_menu clearfix"><li><a href="/lodestone/character/33000046/#profile">Profile</a></li><li class="character_menu__link"><a href="/lodestone/character/33000046/class_job/">Class/Job</a></li><li class="character_menu__link"><a href="javascript:void(null)" class="selected">Minions</a></li><li class="disable"><span class="disable">Mounts</span></li><li class="character_menu__link"><a href="/lodestone/character/33000046/following/">Follow</a></li></ul>
+
+
+
+
+				<div class="character__content selected">
+
+					<h3 class="heading--md">Minions</h3>
+
+					<div class="minion__sort">
+
+						<p class="minion__sort__total">Total: <span>1</span></p>
+					</div>
+
+					<div class="character__minion">
+						<ul class="character__icon__list js__minion_tooltip js__minion_list">
+							<li class="minion__list_icon"data-tooltip_href="/lodestone/character/33000046/minion/tooltip/ac60009967da53c037649e3287f1d56385ce348d"><div class="character__item_icon"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/d8/d8666795d88025ac8283db68e5df2aa337a51749.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon--frame"></div><img src="https://img.finalfantasyxiv.com/lds/h/H/460ZBYyhODi1RNXXV-1hck8V40.png" width="48" height="48" alt="" class="character__item_icon__hover"></div></li>
+						</ul>
+					</div>
+
+				</div>
+			</div>
+		</div>
+
+		<div class="ldst__side">
+
+
+
+
+			<div class="l__rside__bnr clearfix">
+				<a href="https://forum.square-enix.com/ffxiv/forum.php?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_forum" target="_blank" class="l__rside__bnr--forums"><img src="https://img.finalfantasyxiv.com/lds/h/i/i3r6u3moBzQFfijSTu9k3EJirQ.png" width="100" height="62" alt="Forums"></a><a href="https://sqex.to/Msp?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_mogstation" target="_blank" class="l__rside__bnr--mog_station"><img src="https://img.finalfantasyxiv.com/lds/h/3/GjsnqfVxPQrE4Jve8GvKZABF5w.png" width="100" height="62" alt="Mog Station"></a><a href="/pr/blog/?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_officalblog" target="_blank" class="l__rside__bnr--blog"><img src="https://img.finalfantasyxiv.com/lds/h/d/nVeXvIIStLv3npokivV0EzkKwI.png" width="100" height="62" alt="Official Blog"></a>
+			</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+			<div class="mb10"><a href="/endwalker/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_endwalker"><img src="https://img.finalfantasyxiv.com/lds/banner/998/v60_211207_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="https://store.finalfantasyxiv.com/ffxivstore/en-gb/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_onlinestore" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/banner/916/LDS_ffxivos_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/special/2022/All_Saints_Wake/rjk7wevhuy?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_all_saints_wake"><img src="https://img.finalfantasyxiv.com/lds/banner/1119/mnbn_all_saints_wake-1_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/community_finder/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_cf202112"><img src="https://img.finalfantasyxiv.com/lds/banner/1104/LDS_CF_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/jobguide/battle/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_jobguide"><img src="https://img.finalfantasyxiv.com/lds/banner/1089/jobguide_v60_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/uiguide/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_uiguide"><img src="https://img.finalfantasyxiv.com/lds/banner/671/pc_uiguide_eu.jpg"></a></div>
+
+
+
+			<div class="conducting_area">
+
+				<img src="https://img.finalfantasyxiv.com/lds/h/z/EhLfs3eya3Aidfr8A6PbXOBgtA.png" width="300" height="218" alt="">
+
+				<div class="inr">
+					<a href="
+				http://freetrial.finalfantasyxiv.com/" class="bt_conducting">
+						<img src="https://img.finalfantasyxiv.com/lds/h/s/3KRua4vzZJvRXn0IMk8Da103bw.png" width="284" height="80" alt="Start Your Free Trial">
+					</a>
+					<a href="/product/?utm_source=lodestone&utm_medium=pc_buyarea&utm_campaign=eu_buynow" class="bt_conducting" target="_blank">
+						<img src="https://img.finalfantasyxiv.com/lds/h/p/to8CzK_gktAHpLuSGzCkNdLfWo.png" width="284" height="80" alt="BUY NOW!">
+					</a>			<a href="https://support.eu.square-enix.com/faqarticle.php?id=5383&la=2&kid=78775" onmousedown="ga('send', 'event', 'lodestone_eu', 'howtoupgrade_link', 'EU-lodestone-UG_20170620', true);" class="bt_ft_migration">			<img src="https://img.finalfantasyxiv.com/lds/h/0/5rrJdYAcP3if6zX6d62dHV3t34.png" width="260" height="80" alt="Upgrade Your Free Trial<br />to the Full Version">
+				</a>
+				</div>
+			</div>
+
+
+
+
+
+
+
+
+
+			<div class="mb10"><a href="/tales_of_adventure/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_tales_of_adventure"><img src="https://img.finalfantasyxiv.com/lds/banner/1079/LDS_Tales_of_Adventure_v60_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/special/friend_recruit/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_friendrecruit"><img src="https://img.finalfantasyxiv.com/lds/banner/203/bn_Recruit_a_Friend_eu.png"></a></div>
+
+
+
+
+
+
+			<div class="ldst__side__box">
+
+
+
+				<div class="heading--side">
+					<h3>Community Wall</h3>
+					<a href="/lodestone/community/" class="heading--side__icon icon-list__side js__tooltip" data-tooltip="See More"></a>
+				</div>
+				<div class="heading__icon parts__space--reset js__toggle_wrapper">
+					<h4>Recent Activity</h4>
+					<i class="icon-btn__filter js__toggle_trigger js__tooltip" data-tooltip="Filter"></i>
+					<div class="parts__switch parts__switch--filter js__toggle_item">
+						<p class="parts__text">
+							Filter which items are to be displayed below.<br>
+							<span class="parts__text__notes">
+				* Notifications for standings updates are shared across all Worlds.<br>
+				* Notifications for PvP team formations are shared for all languages.<br>
+				* Notifications for free company formations are shared for all languages.
+			</span>
+						</p>
+
+
+						<div class="form__horizontal js__communitywall_filter">
+							<input type="hidden" name="order" value=""><h5 class="heading--side--lead">Sort by</h5><ul class="form__row parts__spce--8"><li><input type="checkbox" name="community_type" value="blog" class="form__checkbox" id="community_type01"><label class="form__checkbox__label" for="community_type01">Blog</label></li><li><input type="checkbox" name="community_type" value="event" class="form__checkbox" id="community_type02"><label class="form__checkbox__label" for="community_type02">Event & Party Recruitment</label></li><li><input type="checkbox" name="community_type" value="fc" class="form__checkbox" id="community_type03"><label class="form__checkbox__label" for="community_type03">Free Company</label></li><li><input type="checkbox" name="community_type" value="db" class="form__checkbox" id="community_type04"><label class="form__checkbox__label" for="community_type04">Eorzea Database</label></li><li><input type="checkbox" name="community_type" value="ranking" class="form__checkbox" id="community_type05"><label class="form__checkbox__label" for="community_type05">Standings</label></li><li><input type="checkbox" name="community_type" value="pvpteam" class="form__checkbox" id="community_type06"><label class="form__checkbox__label" for="community_type06">PvP Team</label></li><li><input type="checkbox" name="community_type" value="community_finder" class="form__checkbox" id="community_type07"><label class="form__checkbox__label" for="community_type07">Community Finder</label></li></ul><h5 class="heading--side--lead">Data Center / Home World</h5><div class="select-pulldown"><label class="control-label" for="world"></label><select name="community_worldname" class="select-pulldown__open"><option value="">Select All</option><optgroup label="Data Center"><option value="_dc_Elemental">Elemental</option><option value="_dc_Gaia">Gaia</option><option value="_dc_Mana">Mana</option><option value="_dc_Aether">Aether</option><option value="_dc_Primal">Primal</option><option value="_dc_Crystal">Crystal</option><option value="_dc_Chaos">Chaos</option><option value="_dc_Light">Light</option></optgroup><optgroup label="Home World"><option value="Adamantoise">Adamantoise</option><option value="Aegis">Aegis</option><option value="Alexander">Alexander</option><option value="Anima">Anima</option><option value="Asura">Asura</option><option value="Atomos">Atomos</option><option value="Bahamut">Bahamut</option><option value="Balmung">Balmung</option><option value="Behemoth">Behemoth</option><option value="Belias">Belias</option><option value="Brynhildr">Brynhildr</option><option value="Cactuar">Cactuar</option><option value="Carbuncle">Carbuncle</option><option value="Cerberus">Cerberus</option><option value="Chocobo">Chocobo</option><option value="Coeurl">Coeurl</option><option value="Diabolos">Diabolos</option><option value="Durandal">Durandal</option><option value="Excalibur">Excalibur</option><option value="Exodus">Exodus</option><option value="Faerie">Faerie</option><option value="Famfrit">Famfrit</option><option value="Fenrir">Fenrir</option><option value="Garuda">Garuda</option><option value="Gilgamesh">Gilgamesh</option><option value="Goblin">Goblin</option><option value="Gungnir">Gungnir</option><option value="Hades">Hades</option><option value="Hyperion">Hyperion</option><option value="Ifrit">Ifrit</option><option value="Ixion">Ixion</option><option value="Jenova">Jenova</option><option value="Kujata">Kujata</option><option value="Lamia">Lamia</option><option value="Leviathan">Leviathan</option><option value="Lich">Lich</option><option value="Louisoix">Louisoix</option><option value="Malboro">Malboro</option><option value="Mandragora">Mandragora</option><option value="Masamune">Masamune</option><option value="Mateus">Mateus</option><option value="Midgardsormr">Midgardsormr</option><option value="Moogle">Moogle</option><option value="Odin">Odin</option><option value="Omega">Omega</option><option value="Pandaemonium">Pandaemonium</option><option value="Phoenix">Phoenix</option><option value="Ragnarok">Ragnarok</option><option value="Ramuh">Ramuh</option><option value="Ridill">Ridill</option><option value="Sargatanas">Sargatanas</option><option value="Shinryu">Shinryu</option><option value="Shiva">Shiva</option><option value="Siren">Siren</option><option value="Spriggan">Spriggan</option><option value="Tiamat">Tiamat</option><option value="Titan">Titan</option><option value="Tonberry">Tonberry</option><option value="Twintania">Twintania</option><option value="Typhon">Typhon</option><option value="Ultima">Ultima</option><option value="Ultros">Ultros</option><option value="Unicorn">Unicorn</option><option value="Valefor">Valefor</option><option value="Yojimbo">Yojimbo</option><option value="Zalera">Zalera</option><option value="Zeromus">Zeromus</option><option value="Zodiark">Zodiark</option></optgroup></select></div><h5 class="heading--side--lead">Primary language</h5><div class="select-pulldown"><label class="control-label" for="lang"></label><select name="community_lang" class="select-pulldown__open"><option value="">Select All</option><option value="ja">Japanese</option><option value="en">English</option><option value="de">German</option><option value="fr">French</option></select></div><h5 class="heading--side--lead">Displaying</h5><div class="select-pulldown"><label class="control-label" for="limit"></label><select name="community_limit" class="select-pulldown__open"><option value="10">10</option><option value="20">20</option><option value="30">30</option></select></div><div class="form__submit form__submit--full"><input type="submit" value="Filter" class="js__bt_communitywall_filter"></div>
+						</div>
+
+
+					</div>
+				</div>
+
+
+				<ul class="side__list__box">
+
+
+					<div class="entry more_"><a href="/lodestone/character/40644630/blog/4942274/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-900f6d72ed5" class="datetime_dynamic_ymdhm" data-epoch="1642767639">-</span><script>document.getElementById('datetime-900f6d72ed5').innerHTML = ldst_strftime_dynamic_ymdhm(1642767639);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Bibi Tunbas</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Mandragora&nbsp;(Mana)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Bibi Tunbas (<i class="xiv-lds xiv-lds-home-world"></i>Mandragora) posted a new blog entry, "サ、サ、サ、サベネアァァァ〜〜〜〜！！！！."</p></div></div></div></a><a href="/lodestone/character/40644630/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/8c41ec432f747f1e95da1f55c3d8d1a3_ee738654add55c3d07ea92d8e108074cfc0_96x96.jpg?1642766986" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/26422021/blog/4942272/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-664b8731a99" class="datetime_dynamic_ymdhm" data-epoch="1642767626">-</span><script>document.getElementById('datetime-664b8731a99').innerHTML = ldst_strftime_dynamic_ymdhm(1642767626);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Tanaty Miston</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Gungnir&nbsp;(Elemental)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Tanaty Miston (<i class="xiv-lds xiv-lds-home-world"></i>Gungnir) posted a new blog entry, "【日記】地図ツアー今月もやります."</p></div></div></div></a><a href="/lodestone/character/26422021/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/19ea06334ab9a5ca736793ee1babbf43_8f82f937943b6baf4c565020d5eba0ccfc0_96x96.jpg?1642767565" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/22869886/blog/4942271/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-6ae1d12cac6" class="datetime_dynamic_ymdhm" data-epoch="1642767549">-</span><script>document.getElementById('datetime-6ae1d12cac6').innerHTML = ldst_strftime_dynamic_ymdhm(1642767549);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Yakkuru Imu</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Atomos&nbsp;(Elemental)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Yakkuru Imu (<i class="xiv-lds xiv-lds-home-world"></i>Atomos) posted a new blog entry, "恐怖！音が鳴ったら順番にマクロ押すだけ士."</p></div></div></div></a><a href="/lodestone/character/22869886/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/6522ae817557ddb610a62c3af73aab92_cf768a751b1f5e355c2fd39a9ed91f3ffc0_96x96.jpg?1642766657" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/35811278/blog/4941646/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-de0160ef86d" class="datetime_dynamic_ymdhm" data-epoch="1642767549">-</span><script>document.getElementById('datetime-de0160ef86d').innerHTML = ldst_strftime_dynamic_ymdhm(1642767549);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Malu Design</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Zeromus&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Malu Design (<i class="xiv-lds xiv-lds-home-world"></i>Zeromus) posted a new blog entry, "初めてイベント募集してみた----からのお礼."</p></div></div></div></a><a href="/lodestone/character/35811278/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/3b626fe0af2a05cb78cdf262b187d00d_c76848359d0b4d2f37aefbb9903ed97bfc0_96x96.jpg?1642765110" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/19045024/blog/4942270/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-d44ff1aa43f" class="datetime_dynamic_ymdhm" data-epoch="1642767360">-</span><script>document.getElementById('datetime-d44ff1aa43f').innerHTML = ldst_strftime_dynamic_ymdhm(1642767360);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Cheesecake Danish</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ifrit&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Cheesecake Danish (<i class="xiv-lds xiv-lds-home-world"></i>Ifrit) posted a new blog entry, "準備不足の特殊FATE、そして、守護天節."</p></div></div></div></a><a href="/lodestone/character/19045024/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/8cf976f182290f8eb112dea3de39f903_f9f796348bc43067c7242ec4551cde69fc0_96x96.jpg?1642764420" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/39466622/blog/4942269/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-b06f4e130fb" class="datetime_dynamic_ymdhm" data-epoch="1642767322">-</span><script>document.getElementById('datetime-b06f4e130fb').innerHTML = ldst_strftime_dynamic_ymdhm(1642767322);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Lilina Shinonome</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ixion&nbsp;(Mana)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Lilina Shinonome (<i class="xiv-lds xiv-lds-home-world"></i>Ixion) posted a new blog entry, "わかってはいるんだけどね・・・."</p></div></div></div></a><a href="/lodestone/character/39466622/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/854d3c933801b806bcc3de04a51267ae_7126768d768f6c6c7fed3eaee98c3a8afc0_96x96.jpg?1642764300" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/23073189/blog/4942266/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-8955c17d566" class="datetime_dynamic_ymdhm" data-epoch="1642767082">-</span><script>document.getElementById('datetime-8955c17d566').innerHTML = ldst_strftime_dynamic_ymdhm(1642767082);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Pon Rookie</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ifrit&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Pon Rookie (<i class="xiv-lds xiv-lds-home-world"></i>Ifrit) posted a new blog entry, "【ポンデの日常風景】メンバーが釣ってきた「ヌシ」がFCハウスに！の巻."</p></div></div></div></a><a href="/lodestone/character/23073189/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/c858102927ab63ede56d07b2f280210d_f9f796348bc43067c7242ec4551cde69fc0_96x96.jpg?1642764634" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/freecompany/9230127436295964601/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header--common clearfix"><time class="entry__activity__time"><span id="datetime-3accbcce32b" class="datetime_dynamic_ymdhm" data-epoch="1642767075">-</span><script>document.getElementById('datetime-3accbcce32b').innerHTML = ldst_strftime_dynamic_ymdhm(1642767075);</script></time></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__fc js__tooltip"data-tooltip="Free Company"></span></div><div class="entry__activity__txt--message"><p>Enjoy Club F (Ixion) has been formed.</p></div></div></div></a><div class="entry__activity__link"><img src="https://img.finalfantasyxiv.com/lds/h/9/_Huf58epDlt9vXiO8IIfPXxtXI.png" width="50" height="50" alt=""></div></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/18833809/blog/4941298/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-0b3ecaa67be" class="datetime_dynamic_ymdhm" data-epoch="1642767053">-</span><script>document.getElementById('datetime-0b3ecaa67be').innerHTML = ldst_strftime_dynamic_ymdhm(1642767053);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Killy Toa</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Valefor&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Killy Toa (<i class="xiv-lds xiv-lds-home-world"></i>Valefor) posted a new blog entry, "出来立ておにぎり美味しいです！."</p></div></div></div></a><a href="/lodestone/character/18833809/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/d78c2cdd2b79ef7d6c7af3a6f5daf8ff_485f4777c38002871591fb54f27edc65fc0_96x96.jpg?1642764923" width="40" height="40" alt=""></div></a></div>
+
+
+					<div data-min_id="4838375902" class="entry more_"data-has_next=""><a href="/lodestone/community_finder/5ebf60b6d96adea6ec52db90cc06f92ada4245ff/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-1f61ed15ba5" class="datetime_dynamic_ymdhm" data-epoch="1642766943">-</span><script>document.getElementById('datetime-1f61ed15ba5').innerHTML = ldst_strftime_dynamic_ymdhm(1642766943);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Mameo Mameo</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Yojimbo&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__community_finder js__tooltip"data-tooltip="Community Finder"></span></div><div class="entry__activity__txt--message"><p>Mameo Mameo (<i class="xiv-lds xiv-lds-home-world"></i>Yojimbo) has started recruitment for the cross-world linkshell "Pandmonium 4sou (Gaia)."</p></div></div></div></a><a href="/lodestone/character/39086707/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/0a5d5e3dc34a27aef68ee11ef010d059_4a92c619bde4f34cfa77e05fef21ad85fc0_96x96.jpg?1642766526" width="40" height="40" alt=""></div></a></div>
+
+
+
+
+				</ul>
+
+
+			</div>
+
+
+
+			<div class="ldst__side__box">
+
+
+
+
+				<div class="heading--side">
+					<h3>Standings</h3>
+					<a href="/lodestone/ranking/" class="heading--side__icon icon-list__side js__tooltip" data-tooltip="See More"></a>
+				</div>
+
+
+				<h4 class="heading--side--sm">The Feast Rankings</h4>
+
+				<a href="/lodestone/ranking/thefeast/result/" class="entry__ranking__thefeast">
+					Pre-season is under way!<br>
+					View results of the previous season
+				</a>
+
+
+
+
+				<h4 class="heading--side--sm">Grand Company Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Luke Breitner</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Fenrir&nbsp;(Gaia)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/9658201/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/bb7875f35a390ed9493dfde91c4d0039_d384cf5ad7db803f29799f36ebbc3eadfc0_96x96.jpg?1642766294" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Kiryuin Satsuki</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/7250925/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/ba64ef52323ad0c23edaa3bafc9f4e82_58a84e851e55175d22158ca97af58a1ffc0_96x96.jpg?1642764909" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Ari Nuovo</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Phoenix&nbsp;(Light)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/19970354/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/1eb1b6c06bbadecb3c0f3b8cbb1b07e0_5047bc596a4bab2dc7f7c120bb22dec5fc0_96x96.jpg?1642766146" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+				</ul>
+
+
+
+				<h4 class="heading--side--sm">Free Company Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">brotherhood</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Moogle&nbsp;(Chaos)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9233364398528115650/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/F00_f4d64b4d75ce7d3be3ba37e24ccc7830_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S01_49d2902352dde56ae3c6423a937ac151_00_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">The Syndicate</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9231394073691073564/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/B08_de875598ba3f5ef9fe02858d29c85455_33_40x40.png" width="40" height="40">
+
+							<img src="https://img2.finalfantasyxiv.com/c/F1e_ed8a164ee0086dc3e36d078e76126110_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S5c_c48179b4e96cff6ed7c51da16ca90c11_04_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">CatOfHeart</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Masamune&nbsp;(Mana)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9236882835737003825/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/B0f_8c3fc97865a1c6bfa360c1bce22b9fa0_c0_40x40.png" width="40" height="40">
+
+							<img src="https://img2.finalfantasyxiv.com/c/F04_1223707ec2cfc1bde4ba8f0f85a74b24_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S33_f0483d3975a483769f674866ff99675e_01_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+				</ul>
+
+
+
+				<h4 class="heading--side--sm">Frontline Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Pharis Bloodborne</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ragnarok&nbsp;(Chaos)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/7338237/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/553c62b150030202afb4206e6f758b91_40d57ba713628f3f1ef5ef204b6d76d2fc0_96x96.jpg?1642767663" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Ni Xi</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Malboro&nbsp;(Crystal)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/34789289/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/356072546b70540163fcdc5bf3f1a6f3_2e97c13fdd593d15d543093f8a37b6f0fc0_96x96.jpg?1642766469" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Blueberry Lollipop</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/39019280/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/2be5c15e35dbd1670f814874fff1234b_58a84e851e55175d22158ca97af58a1ffc0_96x96.jpg?1642767672" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Jo Se</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Sargatanas&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/36466361/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/c9e98a67d1423c12fa7b4c38a41e80e0_ba22853447012a24cee115315d6a5bebfc0_96x96.jpg?1642767272" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Kayeson Mon&#39;roux</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Leviathan&nbsp;(Primal)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/36261740/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/f44e37565c9e753a163ffc1a0d5105ea_a91aae52cff9ef65932db06b150ffd47fc0_96x96.jpg?1642766011" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+				</ul>
+
+
+			</div>
+
+
+
+
+
+
+
+
+
+
+		</div>
+
+	</div>
+
+</div>
+
+
+
+<div id="link_spsite" class="link_sp-site"><a href="javascript:void(0)">Mobile Version</a><br></div><footer class="l__footer l__footer__eu"><div class="page-top"><span class="page-top__btn"></span></div><div class="l__footer__inner"><div class="l__footer__logo"><img src="https://img.finalfantasyxiv.com/lds/h/L/EbtcXqPUGzsVYdi23FpUR25oH4.png" width="320" height="32" alt=""></div><p class="l__footer__officiel">Official Information</p><ul class="l__footer__sns"><li><a href="https://www.facebook.com/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-facebook xiv-lds-3x"></i><span>Facebook</span></a></li><li class="l__footer__sns--twitter"><a href="https://twitter.com/ff_xiv_en" target="_blank"><i class="xiv-lds xiv-lds-twitter xiv-lds-3x"></i>Twitter</a> / <a href="https://twitter.com/FFXIV_NEWS_EN" target="_blank">Twitter News</a></li><li><a href="http://www.youtube.com/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-youtube xiv-lds-3x"></i><span>Official Channel</span></a></li><li><a href="https://www.instagram.com/ffxiv/" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-instagram xiv-lds-3x"></i><span>Instagram</span></a></li><li><a href="https://www.twitch.tv/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-twitch xiv-lds-3x"></i><span>Twitch</span></a></li></ul><ul class="l__footer__link-list"><li class="link_license" id="link_license"><a href="/license/" target="_blank">License</a></li><li><a href="https://support.eu.square-enix.com/rule.php?id=5383&la=2" target="_blank">Rules & Policies</a></li><li><a href="https://square-enix-games.com/en_GB/documents/privacy" target="_blank">Privacy Policy</a></li><li><a href="https://square-enix-games.com/en_GB/documents/cookies" target="_blank">Cookie Policy</a></li></ul></div><div class="l__footer__legal-area"><div class="l__footer__legal-area__inner clearfix"><div class="l__footer__legal-area__box"><ul class="l__footer__legal-area__bnr-list"><li><a href="http://www.pegi.info" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/h/8/bLhWLeqRDavUCuBhK8X0yB9bKA.png" width="41" height="50" alt="PEGI"></a></li><li><img src="https://img.finalfantasyxiv.com/lds/h/D/egrXwtjrQC8nFGhA1rWb0PO8R0.png" width="245" height="39" alt="PlayStation PS5 PS4"></li><li><img src="https://img.finalfantasyxiv.com/lds/h/E/38lyWv84H59UEwldgCOGU2B9dM.png" width="33" height="39" alt="PC"></li><li><img src="https://img.finalfantasyxiv.com/lds/h/v/hyXqlwktN4v0EssRTzkbMf_7OQ.png" width="30" height="39" alt="Mac"></li><li class="last"><img src="https://img.finalfantasyxiv.com/lds/h/U/15QxPO___EcPlhMI9ydNRRxEY8.png" width="90" height="39" alt="STEAM"></li></ul><p class="l__footer__legal-area__text">“<i class="ps"></i>”, “PlayStation”, “<i class="ps5"></i>” and “<i class="ps4"></i>” are registered trademarks or trademarks of Sony Interactive Entertainment Inc.<br />Mac is a trademark of Apple Inc.<br />©2021 Valve Corporation. Steam and the Steam logo are trademarks and/or registered trademarks of Valve Corporation in the U.S. and/or other countries.</p></div><div class="l__footer__legal-area__box"><p class="l__footer__legal-area__copyright">© 2010 - 2022 <a href="https://square-enix-games.com/en_GB" target="_blank">SQUARE ENIX</a> CO., LTD. All Rights Reserved.<br>ENDWALKER, SHADOWBRINGERS, STORMBLOOD, HEAVENSWARD and A REALM REBORN are registered trademarks or trademarks of Square Enix Co., Ltd.<br />FINAL FANTASY, FINAL FANTASY XIV, FFXIV, SQUARE ENIX and the SQUARE ENIX logo are registered trademarks or trademarks of Square Enix Holdings Co., Ltd.<br>LOGO ILLUSTRATION: © 2010, 2014, 2016, 2018, 2021 YOSHITAKA AMANO</p></div></div></div></footer>
+
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-43364669-4"></script>
+<script>
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+
+	(function() {
+		var gtag_config = {
+			'link_attribution': true,
+			'custom_map': {
+				'dimension1': 'login',
+				'dimension2': 'theme',
+				'dimension3': 'mychara',
+				'dimension4': 'character_link'
+			},
+			'login': 'notloginuser',
+			'theme':  'white',
+		};
+
+
+		gtag('js', new Date());
+
+		gtag('config', 'UA-43364669-4', gtag_config);
+		gtag('config', 'UA-43364669-1', gtag_config);
+	})();
+</script>
+
+
+
+
+<script src="https://img.finalfantasyxiv.com/lds/pc/en-gb/js/i18n.js?1642399092"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/i/2ur_0e4qXk_NwNv0bGjrUHThCM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/g/uQNBgvCaabd4gw5kMpaT-psp1Q.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/b/RKD_bGx738E81TyiPQN4kGf-_Y.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/Z/wqo4GxX1wALdnxx6xOv38NxFVY.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/e/TSPHxkEhdcyaPMm0rpoBtk1dZA.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/P/O9-IKBqOphhkhVvm2QPrR9x5p4.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/9/TTeYt1mN0BF3R1Av3fWlknchv4.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/8/b_tPmOnEw1tyr2dp2InkGxUlMA.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/Y/6WaukM6m3WFE2JXrCEb6tsknik.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/E/ImNUSWkI-O9dQP5ADa41RiGxGY.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/t/kQLYFR8rOESAOiyT9o2PsRnLq0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/C/q1cplyit_St5sY1BUgBKFuLapM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/s/Gt4XmT3a3nu52yKZPoVWcvrfFM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/A/LATlIIBarKmGFTTVid87k_GPFg.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/W/r-0ziwRwdsVj1lEyFHfmVyFgKw.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/piXyeCeUEtNAzCIq6jXoqNimzE.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/t/85HyWVlETnECMXo9l40HahjdO0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/OIfkF0BnyASNQ0RswButWbIKCU.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/U/jhEwPt7MvJy47-ExjjZ3lHW3qI.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/0/f52zA7ACWvjEMB1oWe8kfyGWH0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/l/-_ePiHXNE_1t8LnRcmRAbhRME8.js"></script>
+<script src="https://www.youtube.com/iframe_api"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/P/MYGDtxveSuUwuhprm8oj1Hhuq8.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/it7tc9wvjlJJstEQUNjiModhdM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/n/HMQm8_JEoqrSmuv5RmmKgTldGc.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/B/ElvNJhxzt4ULBYHMPrt3JiAKGU.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/s/Nd8g9tCAy5oNnteBvnvPkUlQM0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/d/UfPsCOe_Nl7ytqem4KWdsftkY0.js"></script>
+
+
+<div id="dialog_bg" style="opacity:0; visibility: hidden;"></div>
+<!-- dialog -->
+<div name="ldstDialog" class="overlay__area js__overlay" style="opacity:0; visibility: hidden; top: 0px">
+	<p class="overlay__text--icon"></p>
+
+	<div class="outbound_consent hide">
+		<input type="checkbox" name="outbound_consent" value="1" id="outbound_consent" class="form__checkbox">
+		<label for="outbound_consent" class="form__checkbox__label form__outbound">
+			Do not show this message again.
+		</label>
+	</div>
+
+	<!-- SIMPLE DIALOG -->
+	<a href="javascript:void(0);" class="js__dialog_btn btn__color--radius js__overlay_ok">Confirm</a>
+	<!-- //SIMPLE DIALOG -->
+	<!-- CONFIRM DIALOG -->
+	<ul class="js__dialog_btn overlay__btn js__overlay_btn">
+		<li><a href="javascript:void(0);" class="js__overlay_yes">Yes</a></li>
+		<li><a href="javascript:void(0);" class="js__overlay_no">No</a></li>
+	</ul>
+	<!-- //CONFIRM DIALOG -->
+</div>
+<!-- //dialog -->
+
+
+
+
+</body>
+</html>

--- a/src/test/resources/data/lodestone/Character-33000046.html
+++ b/src/test/resources/data/lodestone/Character-33000046.html
@@ -1,0 +1,1322 @@
+<!DOCTYPE html>
+<html lang="en-gb" class="en-gb" xmlns:og="http://ogp.me/ns#" xmlns:fb="http://www.facebook.com/2008/fbml">
+<head><meta charset="utf-8">
+
+	<!-- Google Tag Manager -->
+	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	})(window,document,'script','digitalData','GTM-P37XSWJ');</script>
+	<!-- End Google Tag Manager -->
+
+	<title>K&#39;ewl D&#39;eeps | FINAL FANTASY XIV, The Lodestone</title>
+	<meta name="description" content="Character profile for K&#39;ewl D&#39;eeps.">
+	<meta name="keywords" content="FF14,FFXIV,Final Fantasy XIV,Final Fantasy 14,Lodestone,players' site,community site,A Realm Reborn,Heavensward,Stormblood,Shadowbringers,Endwalker,MMO">
+	<meta name="author" content="SQUARE ENIX Ltd.">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="format-detection" content="telephone=no">
+
+	<link rel="shortcut icon" type="image/vnd.microsoft.icon" href="https://img.finalfantasyxiv.com/lds/pc/global/images/favicon.ico?1490749553">
+	<link rel="apple-touch-icon-precomposed" href="https://img.finalfantasyxiv.com/lds/h/0/U2uGfVX4GdZgU1jASO0m9h_xLg.png">
+	<meta name="msapplication-TileImage" content="https://img.finalfantasyxiv.com/lds/h/0/U2uGfVX4GdZgU1jASO0m9h_xLg.png">
+
+	<meta name="msapplication-TileColor" content="#000000">
+	<link rel="alternate" hreflang="ja" href="https://jp.finalfantasyxiv.com/lodestone/character/33000046">
+	<link rel="alternate" hreflang="en-us" href="https://na.finalfantasyxiv.com/lodestone/character/33000046">
+	<link rel="alternate" hreflang="fr" href="https://fr.finalfantasyxiv.com/lodestone/character/33000046">
+	<link rel="alternate" hreflang="de" href="https://de.finalfantasyxiv.com/lodestone/character/33000046">
+
+
+	<meta name="google-site-verification" content="WwpBRGfcVWgP_LxTs8PHc6EcDM8eCt8Zqck1MAnVmZM">
+
+
+
+
+	<!--[if lt IE 9]>
+	<script src="https://img.finalfantasyxiv.com/lds/h/I/SMlNRnAvuilc1lYKBpzKWpmADs.js"></script>
+
+	<![endif]-->
+	<!-- ** CSS ** -->
+	<link href="https://img.finalfantasyxiv.com/lds/h/M/0kxkkawCCBg1ArBrU_c1cydINM.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/-/tUrZCLFtMgzaHil2OXxbmdw2a0.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/l/6D7j33OWZQd8eVk8IKWT15deH8.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/j/JgAulXN0McN_xRNcKLLbnNh4fs.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/F/wZHqGlYFe-0or10VJJtARsKyko.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/a/bmAvctt6TxsMwvFeI4NiKcWnZM.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/Q/mAASajjDE39sDOGkuOPDZPBt0s.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/w/YgRYdK0dq3N9UCU6nR-7J5PftA.css" rel="stylesheet">
+
+	<link href="https://img.finalfantasyxiv.com/lds/h/b/tInX1HM2lXTimf4ts8i-7wWr1Y.css" rel="stylesheet">
+
+	<link href="https://img.finalfantasyxiv.com/lds/h/w/cuKVxIZUo5Tf3xQ8a9_mn8jZDU.css" rel="stylesheet"
+		  class="sys_theme_css"
+
+		  data-theme_white="https://img.finalfantasyxiv.com/lds/h/w/cuKVxIZUo5Tf3xQ8a9_mn8jZDU.css"
+
+		  data-theme_black="https://img.finalfantasyxiv.com/lds/h/o/q3zLnccpt9t--buuJJqeuTpzOY.css"
+
+	>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<!-- ogp -->
+	<meta property="fb:app_id" content="1400886233468625">
+	<meta property="og:type" content="website">
+	<meta property="og:description" content="Character profile for K&#39;ewl D&#39;eeps.">
+	<meta property="og:title" content="K&#39;ewl D&#39;eeps | FINAL FANTASY XIV, The Lodestone">
+	<meta property="og:url" content="https://eu.finalfantasyxiv.com/lodestone/character/33000046">
+	<meta property="og:site_name" content="FINAL FANTASY XIV, The Lodestone">
+	<meta property="og:locale" content="en_GB">
+
+	<meta property="og:image" content="https://img.finalfantasyxiv.com/lds/h/I/cy_FoBlOdFg3kBAQdaAxT19pTw.png">
+
+
+
+	<meta property="fb:pages" content="116214575870">
+
+
+	<meta name="twitter:card" content="summary_large_image">
+
+	<meta name="twitter:site" content="@ff_xiv_en">
+
+
+
+
+	<script>
+		var base_domain = 'finalfantasyxiv.com';
+		var ldst_subdomain = 'eu';
+		var strftime_fmt = {
+			'dateHHMM_now': 'Today %H:%M',
+			'dateYMDHMS': '%d/%m/%Y %H:%M:%S',
+			'dateYMDHM': '%d/%m/%Y %H:%M',
+			'dateYMDHM_jp': '%Y/%m/%d %H:%M',
+			'dateHM': '%H:%M',
+			'dateYMDH': '%d/%m/%Y %H',
+			'dateYMD': '%d/%m/%Y',
+			'dateEternal': '%d.%m.%Y',
+			'dateYMDW': '%d/%m/%Y (%a)',
+			'dateHM': '%H:%M',
+			'week.0': 'Sun.',
+			'week.1': 'Mon.',
+			'week.2': 'Tue.',
+			'week.3': 'Wed.',
+			'week.4': 'Thu.',
+			'week.5': 'Fri.',
+			'week.6': 'Sat.'
+		};
+		var base_uri   = '/lodestone/';
+		var api_uri    = '/lodestone/api/';
+		var static_uri = 'https://img.finalfantasyxiv.com/lds/';
+		var subdomain  = 'eu';
+		var csrf_token = 'c2d62bcbb971502d94e68b23f00e35bbf2229479';
+		var cis_origin = 'https://secure.square\u002denix.com';
+		var ldst_max_image_size = 31457280;
+		var eorzeadb = {
+			cdn_prefix: 'https://img.finalfantasyxiv.com/lds/',
+			version: '1641278251',
+			version_js_uri:  'https://img.finalfantasyxiv.com/lds/pc/global/js/eorzeadb/version.js',
+			dynamic_tooltip: false
+		};
+		var cookie_suffix = '';
+		var ldst_is_loggedin = false;
+		var show_achievement = false;
+	</script>
+	<script src="https://img.finalfantasyxiv.com/lds/h/A/PknAmzDJUZCNhTGtSGGMIGi5k4.js"></script>
+	<script src="https://img.finalfantasyxiv.com/lds/h/H/hBuD3_ZXTqwHX64YYCchtvgGSs.js"></script>
+
+
+
+
+
+
+
+
+
+</head>
+<body id="community" class=" lang_eu">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P37XSWJ"
+				  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+
+
+
+<div class="brand"><div class="brand__section">
+	<div class="brand__logo">
+		<a href="
+				https://square-enix-games.com/en_GB
+			" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/h/L/cxcD5kjeM52JRVwrrzIF4dZNe0.png" width="130" height="14" alt="SQUARE ENIX">
+		</a>
+	</div>
+
+
+	<div class="brand__search">
+		<form action="/lodestone/community/search/" class="brand__search__form">
+			<div class="brand__search__focus_bg"></div>
+			<div class="brand__search__base_bg"></div>
+			<input type="text" id="txt_search" class="brand__search--text" name="q" placeholder="Search">
+			<input type="submit" id="bt_search" class="brand__search--btn" value="">
+		</form>
+	</div>
+
+
+
+	<div class="brand__theme sys_theme_switcher">
+		<a href="javascript:void(0);"><i class="brand__theme--white sys_theme active js__tooltip" data-tooltip="Theme (Black)" data-theme="white"></i></a>
+		<a href="javascript:void(0);"><i class="brand__theme--black sys_theme js__tooltip" data-tooltip="Theme (White)" data-theme="black"></i></a>
+	</div>
+
+
+	<div class="brand__lang dropdown_trigger_box">
+		<a href="javascript:void(0);" class="brand__lang__btn brand__lang__en-gb dropdown_trigger">English</a>
+		<ul class="brand__lang__select dropdown">
+
+			<li><a href="https://jp.finalfantasyxiv.com/lodestone/character/33000046" class="brand__lang__jp">日本語</a></li>
+
+			<li><a href="https://na.finalfantasyxiv.com/lodestone/character/33000046" class="brand__lang__na">English</a></li>
+
+			<li><a href="https://eu.finalfantasyxiv.com/lodestone/character/33000046" class="brand__lang__eu">English</a></li>
+
+			<li><a href="https://fr.finalfantasyxiv.com/lodestone/character/33000046" class="brand__lang__fr">Français</a></li>
+
+			<li><a href="https://de.finalfantasyxiv.com/lodestone/character/33000046" class="brand__lang__de">Deutsch</a></li>
+
+		</ul>
+	</div>
+
+
+
+	<div class="l__cross_menu eu">
+		<a href="javascript:void(null)" class="ffxiv_pr_cross_menu_button_eu"></a>
+		<script>
+			var ffxiv_pr_cross_menu = {
+				uri_js: '/cross_menu/uri.js'
+			};
+		</script>
+		<script src="https://img.finalfantasyxiv.com/lds/promo/pc/global/menu/loader.js"></script>
+	</div>
+
+</div></div>
+
+
+
+
+<header class="l__header">
+	<div class="l__header__inner l__header__bg_image" style="background-image: url(https://img.finalfantasyxiv.com/lds/banner/1074/headerImage_6_0_eu.jpg);">
+		<a href="/lodestone/" class="l__header__link_top"></a>
+
+
+		<a href="/lodestone/topics/detail/66a742165e9415790247c1a1f7d909abf5becb5c/?utm_source=lodestone&amp;utm_medium=pc_header&amp;utm_campaign=eu_6_0patch" class="l__header__link_management"></a>
+
+
+		<div class="l__header__login clearfix"><a href="/lodestone/account/login/" class="l__header__login__btn">
+			<img src="https://img.finalfantasyxiv.com/lds/h/z/6PLTZ82M99GJ7tKOee1RSwvNrQ.png" width="40" height="40" alt="" class="l__header__login__chara_silhouette">
+			<div class="l__header__login__txt">
+				<p>View Your Character Profile</p>
+				<div>Log In</div>
+			</div>
+		</a></div>
+
+
+	</div>
+</header>
+
+
+
+
+
+
+
+
+
+
+<div class="global-nav">
+	<nav class="main-nav eu">
+		<ul class="main-nav__area main-nav__area__community clearfix ">
+			<li class="main-nav__news main-nav__item">
+				<a href="/lodestone/news/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_news-top');"><span>News</span></a>
+				<nav class="sub-nav">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__news">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__news__icon">
+									<li>
+										<a href="/lodestone/news/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_top');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/8/2GwuzUcvqLa-hgQeLUyd8xarI8.png" width="32" height="32" alt="News">
+											News
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/topics/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_topics');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/5/67ZyAIzQUaYoWBmyvFwNvGmCnQ.png" width="32" height="32" alt="Topics">
+											Topics
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/1" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_notices');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/-/Y5JdwnEWYfyO7OlH27eKIm91Ok.png" width="32" height="32" alt="Notices">
+											Notices
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/2" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_maintenance');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/s/-JfULvMAf26L7AaU1OGaGYwanI.png" width="32" height="32" alt="Maintenance">
+											Maintenance
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/3" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_updates');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/p/HPudyOQcwdv97RBwj3FQC552ps.png" width="32" height="32" alt="Updates">
+											Updates
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/4" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_Status');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/S/-IC2xIQhTl2ymYW7deE1fOII04.png" width="32" height="32" alt="Status">
+											Status
+										</div></a>
+									</li>
+								</ul>
+								<ul class="sub-nav__news__text">
+									<li><a href="/lodestone/special/patchnote_log/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_patch-notes_special-sites');"><div>
+										Patch Notes and Special Sites
+										<span class="update">
+											Updated <span id="datetime-7e6cf748856">-</span><script>document.getElementById('datetime-7e6cf748856').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</div></a></li>
+									<li><a href="/lodestone/special/update_log/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_lodestone-update-notes');"><div>
+										<span class="sub_text">Official Community Site</span>
+										The Lodestone Update Notes
+										<span class="update">
+											Updated <span id="datetime-1bd4ff77204">-</span><script>document.getElementById('datetime-1bd4ff77204').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</div></a></li>
+									<li><a href="/lodestone/worldstatus/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_server-status');"><div>
+										Server Status
+									</div></a></li>
+								</ul>
+							</div>
+						</div>
+
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__promotion main-nav__item">
+				<a href="/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_begin-ff14-top');"><span>Getting Started</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__promotion">
+							<div class="sub-nav__list__inner">
+								<div class="sub-nav__promotion__inner">
+									<div class="sub-nav__promotion__link">
+										<div class="sub-nav__promotion__top">
+											<a href="/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_pr');"><img src="https://img.finalfantasyxiv.com/lds/h/P/ciPXy1S4-ssQuLQJvEF4JWVm5Q.jpg" width="632" height="140" alt="FINAL FANTASY XIV: A Realm Reborn"></a>
+										</div>
+										<ul class="sub-nav__promotion__page">
+											<li><a href="/benchmark/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_benchmark');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/S/2_8ofX4E90a7pS-p0mjFK_tc_U.png" width="64" height="40" alt="Benchmark">
+												<span>Benchmark</span>
+											</a></li>
+											<li><a href="
+
+													http://freetrial.finalfantasyxiv.com/
+												" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_freetrial');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/c/tWvZpXDc_g6yQd5YKK2k5jhuns.png" width="64" height="40" alt="Free Trial">
+												<span>Free Trial</span>
+											</a></li>
+											<li><a href="/product/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_product');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/m/NCNLGrn3U9M85ky-NscraujvN8.png" width="64" height="40" alt="Product">
+												<span>Product</span>
+											</a></li>
+											<li><a href="/winning/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_awards');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/j/udWU20sWmhYoEsQ_FtrAzVwJ3Q.png" width="64" height="40" alt="Awards and Nominations">
+												<span>Awards and Nominations</span>
+											</a></li>
+										</ul>
+									</div>
+									<div class="sub-nav__promotion__patch_site">
+										<a href="/endwalker/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_latest-expansion');"><span>
+											<img src="https://img.finalfantasyxiv.com/lds/h/f/sLzgsq-NNdSMdqLt6Mby4oROC0.png" width="296" height="232" alt="FINAL FANTASY XIV: Endwalker Special Site">
+										</span></a>
+									</div>
+								</div>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+			</li>
+			<li class="main-nav__playguide main-nav__item">
+				<a href="/lodestone/playguide/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_playguide-top');"><span>Play Guide</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__playguide">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__playguide__list">
+									<li><a href="/lodestone/playguide/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_playguide-top');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/P/Lfl3LVb9KMPa5Ye8yxftZkelbc.png" width="40" height="40" alt="Play Guide<br />Top">
+										<span>Play Guide<br />Top</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#game_playguide" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_game-playguide');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/q/qy4dUGMNkjoyVqPweYMIpOApik.png" width="40" height="40" alt="Gameplay Guide and<br />Beginners' Guide">
+										<span>Gameplay Guide and<br />Beginners' Guide</span>
+										<span class="update">
+											Updated <span id="datetime-00f4f185ce3">-</span><script>document.getElementById('datetime-00f4f185ce3').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/db/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_databese');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/N/OYPWhQVCkovUbVcMMck0O4HABU.png" width="40" height="40" alt="Eorzea Database">
+										<span>Eorzea Database</span>
+										<span class="update">
+											Updated <span id="datetime-29d60283ca8">-</span><script>document.getElementById('datetime-29d60283ca8').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#content_guide" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_contents-guide');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/W/wlHP1NMpdQHcPKUG-swlv71fhE.png" width="40" height="40" alt="Game Features">
+										<span>Game Features</span>
+										<span class="update">
+											Updated <span id="datetime-5d005a086ff">-</span><script>document.getElementById('datetime-5d005a086ff').innerHTML = ldst_strftime(1638518400, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#side_storyes" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_side-story');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/Z/1QWgBsVU7ZboWyMZlRjCQcDRJg.png" width="40" height="40" alt="Side Stories<br />and More">
+										<span>Side Stories<br />and More</span>
+										<span class="update">
+											Updated <span id="datetime-373c1a7845b">-</span><script>document.getElementById('datetime-373c1a7845b').innerHTML = ldst_strftime(1632470400, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#option_service" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_option-service');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/4fXwcEoJzDEmFRt-tD7PeeKvjE.png" width="40" height="40" alt="Additional Services">
+										<span>Additional Services</span>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__community main-nav__item">
+				<a href="/lodestone/community/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_community-top');"><span>Community</span></a>
+				<nav class="sub-nav">
+					<div class="sub-nav__area">
+
+
+						<div class="sub-nav__list sub-nav__community">
+							<div class="sub-nav__list__inner sub-nav__community__flex">
+								<div class="sub-nav__community__link">
+									<div class="sub-nav__community__top">
+										<div class="sub-nav__community__top__wrapper">
+											<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/q/GiEpnP3oCXluFjrlPlM-mgIbS8.png" width="16" height="16" alt="Community">Community</h2>
+											<ul class="sub-nav__community__list">
+												<li><a href="/lodestone/community/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_community-top');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/i/Sa5YF2-VFf4IJ1cjjFAbPf4GWg.png" width="40" height="40" alt="Community Wall">
+													<span>Community Wall</span>
+												</a></li>
+												<li><a href="/lodestone/blog/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_blog');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/h/6gPbLbzUQ_omC_mdXFUA3zPy7I.png" width="40" height="40" alt="Blog">
+													<span>Blog</span>
+												</a></li>
+											</ul>
+										</div>
+										<div class="sub-nav__community__top__wrapper">
+											<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/d/in_Sbc6SzxLU--Npa7URI-_kdg.png" width="16" height="16" alt="Member Recruitment">Member Recruitment</h2>
+											<ul class="sub-nav__community__list">
+												<li><a href="/lodestone/community_finder/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_community-finder');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/V/kHxwEjpY-Fme83ta8VIfi1kyLU.png" width="40" height="40" alt="Community Finder">
+													<span>Community Finder</span>
+												</a></li>
+												<li><a href="/lodestone/event/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_event-party');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/0/k5jD6-BJZHwKA2CtbNcDYZR6oY.png" width="40" height="40" alt="Event & Party Recruitment">
+													<span>Event & Party Recruitment</span>
+												</a></li>
+											</ul>
+										</div>
+									</div>
+									<div class="sub-nav__community__search">
+										<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/X/uQVT3DEl1xlFWHu3UZU4-RBtVk.png" width="16" height="16" alt="Search">Search</h2>
+										<ul class="sub-nav__community__list sub-nav__community__search__list">
+											<li><a href="/lodestone/character/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_chara-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/5/YcEF3K-5SgqU0BxZtT0D1Zsa2A.png" width="40" height="40" alt="Character Search">
+												<span>Character Search</span>
+											</a></li>
+											<li><a href="/lodestone/linkshell/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_ls-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/b/SPCgcBAk4HvMngGzk6H4MfSINg.png" width="40" height="40" alt="Linkshell Search">
+												<span>Linkshell Search</span>
+											</a></li>
+											<li><a href="/lodestone/crossworld_linkshell/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_cwls-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/L/NUGcPcy-C8jvx6oKgEXgwJ1ePE.png" width="40" height="40" alt="CWLS Search ">
+												<span>CWLS Search </span>
+											</a></li>
+											<li><a href="/lodestone/freecompany/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_fc-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/q/GJ-lsgAtsCCDwCm9te3a5sCjpU.png" width="40" height="40" alt="Free Company Search">
+												<span>Free Company Search</span>
+											</a></li>
+											<li><a href="/lodestone/pvpteam/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_pvp-team-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="PvP Team Search">
+												<span>PvP Team Search</span>
+											</a></li>
+										</ul>
+									</div>
+								</div>
+								<div class="sub-nav__community__side">
+									<div class="sub-nav__community__forum">
+										<ul class="sub-nav__community__forum__list">
+											<li><a href="https://forum.square-enix.com/ffxiv/forum.php" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum');">
+												<div class="forum">
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/r/maZ-sHaqn4PMFANUlbH4GzztFM.png" width="40" height="40" alt="Forums">
+													</i><span>Forums</span>
+												</div>
+											</a></li>
+											<li><a href="https://forum.square-enix.com/ffxiv/search.php?do=getdaily_ll&contenttype=vBForum_Post" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum-new-posts');">
+												<div>
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+													</i><span>New Posts</span>
+												</div>
+											</a></li>
+											<li><a href="
+
+														https://forum.square-enix.com/ffxiv/search.php?do=process&search_type=1&contenttypeid=1&devtrack=1&starteronly=0&showposts=1&childforums=1&forumchoice[]=619
+													" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum-dev-tracker');">
+												<div>
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+													</i><span>Dev Tracker</span>
+												</div>
+											</a></li>
+										</ul>
+									</div>
+									<ul class="sub-nav__community__fankit">
+										<li><a href="/lodestone/special/fankit/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_fankit');">
+											<div>
+												<span>Fan Kit</span>
+												<span class="update">
+													Updated <span id="datetime-ab4fae77e13">-</span><script>document.getElementById('datetime-ab4fae77e13').innerHTML = ldst_strftime(1640332800, 'YMD');</script>
+												</span>
+											</div>
+										</a></li>
+									</ul>
+								</div>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__ranking main-nav__item">
+				<a href="/lodestone/ranking/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_ranking-top');"><span>Standings</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__ranking">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__ranking__list">
+									<li><a href="/lodestone/ranking/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_ranking-top');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/E/NtymEFiUJfAh25ffTrADsVFkLQ.png" width="40" height="40" alt="Standings Top">
+										<span>Standings Top</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/thefeast/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_feast');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="The Feast Rankings">
+										<span>The Feast Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/deepdungeon2/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_deepdungeon2');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/_/qP22LgUoAFKDTRayb_TEYu6d7g.png" width="40" height="40" alt="Heaven-on-High Rankings">
+										<span>Heaven-on-High Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/deepdungeon/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_deepdungeon');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/p/op9iPrlMmYgTK3Q6NQKifyQOGA.png" width="40" height="40" alt="Palace of the Dead Rankings">
+										<span>Palace of the Dead Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/frontline/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_frontline');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="Frontline Standings">
+										<span>Frontline Standings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/gc/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_gc');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/o/uRmujlTx4X_5c6wETNxssK1d_4.png" width="40" height="40" alt="Grand Company Standings">
+										<span>Grand Company Standings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/fc/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_fc');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/q/GJ-lsgAtsCCDwCm9te3a5sCjpU.png" width="40" height="40" alt="Free Company Standings">
+										<span>Free Company Standings</span>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__help main-nav__item">
+				<a href="/lodestone/help/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_help-support-top');"><span>Help & Support</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__help">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__help__list">
+									<li><a href="/lodestone/help/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_help-support-top');">
+										<span>Help & Support</span>
+									</a></li>
+									<li><a href="/lodestone/help/about_the_lodestone/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_about-lodestone');">
+										<span>About the Lodestone</span>
+									</a></li>
+									<li><a href="
+
+											https://support.eu.square-enix.com/faq.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_faq');">
+										<span>FAQ</span>
+									</a></li>
+									<li><a href="
+
+											https://eu.square-enix.com/en/seaccount/
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_sqex-account');">
+										<span>Square Enix Account Information</span>
+									</a></li>
+								</ul>
+								<ul class="sub-nav__help__other">
+									<li><a href="
+
+											https://support.eu.square-enix.com/rule.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_rule-policies');">
+										<div>
+											<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+											</i><span>Rules & Policies</span>
+										</div>
+									</a></li>
+									<li><a href="
+
+											https://support.eu.square-enix.com/main.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_customer-service');">
+										<div>
+											<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+											</i><span>Customer Service</span>
+										</div>
+									</a></li>
+									<li><a href="https://sqex.to/Msp" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_mogstation');">
+										<div>
+											<i class="ic_mogst"><img src="https://img.finalfantasyxiv.com/lds/h/S/6IKp0hN6xQqTYPgnPIsd2fjzSI.png" width="32" height="32" alt="">
+											</i><span>Mog Station</span>
+										</div>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+		</ul>
+	</nav>
+</div>
+
+
+
+
+<div class="ldst__bg">
+
+	<div id="breadcrumb">
+		<ul itemscope itemscope itemtype="https://schema.org/BreadcrumbList" class="clearfix">
+			<li class="breadcrumb__home" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/" itemprop="item"><span itemprop="name">HOME</span></a>
+				<meta itemprop="position" content="1" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/community/" itemprop="item" class="breadcrumb__link"><span itemprop="name">Community</span></a>
+				<meta itemprop="position" content="2" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/character/" itemprop="item" class="breadcrumb__link"><span itemprop="name">Character</span></a>
+				<meta itemprop="position" content="3" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<span itemprop="name">K&#39;ewl D&#39;eeps</span>
+				<meta itemprop="position" content="4" />
+			</li>
+
+
+		</ul>
+	</div>
+
+
+	<h1 class="heading__title">Character</h1>
+
+
+
+	<nav class="btn__corner_block">
+		<ul class="btn__corner_block--3">
+
+			<li>
+				<a href="/lodestone/character/33000046/" class="btn__menu btn__menu--active">Profile</a>
+			</li>
+			<li>
+				<a href="/lodestone/character/33000046/blog/" class="btn__menu">Blog</a>
+			</li>
+			<li>
+				<a href="/lodestone/character/33000046/event/" class="btn__menu">Events</a>
+			</li>
+
+		</ul>
+	</nav>
+
+
+
+	<div class="ldst__contents clearfix">
+
+		<div class="ldst__main">
+
+
+
+			<div id="character" class="ldst__window">
+				<h2 class="heading--lg">Character</h2>
+
+
+
+				<div class="frame__chara js__toggle_wrapper">
+					<a href="/lodestone/character/33000046/" class="frame__chara__link">
+						<div class="frame__chara__face">
+							<img src="https://img2.finalfantasyxiv.com/f/197341aa090981d3cf179d2703eb85bc_284358f8eb4efc9095914e46798c6ab3fc0_96x96.jpg?1642763759" width="40" height="40" alt="">
+						</div>
+						<div class="frame__chara__box">
+
+							<p class="frame__chara__name">K&#39;ewl D&#39;eeps</p>
+
+							<p class="frame__chara__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Coeurl&nbsp;(Crystal)</p>
+						</div>
+					</a>
+					<div class="parts__connect--state js__toggle_trigger">
+
+
+						<i class="parts__connect_off js__tooltip" data-tooltip="You have no connection with this character."></i>
+
+					</div>
+
+					<div class="parts__switch js__toggle_item">
+
+						<p class="character__connect__text">You have no connection with this character.</p>
+
+
+
+
+
+						<div class="heading--md-slide">Follower Requests</div>
+						<p class="entry__toggle__text">Before this character can be followed, you must first submit a follower request.<br />Do you wish to proceed?</p>
+						<ul class="btn__switch character__connect__form">
+							<li><a href="/lodestone/account/login/">Yes</a></li>
+							<li><a href="javascript:void(0)" class="js__toggle_trigger">No</a></li>
+						</ul>
+
+
+
+					</div>
+
+				</div>
+
+				<ul class="character__profile_tab js__character_menu clearfix"><li><a href="javascript:void(0);" id="hash__profile" data-hash="profile">Profile</a></li><li class="character_menu__link"><a href="/lodestone/character/33000046/class_job/">Class/Job</a></li><li class="character_menu__link"><a href="/lodestone/character/33000046/minion/">Minions</a></li><li class="disable"><span class="disable">Mounts</span></li><li class="character_menu__link"><a href="/lodestone/character/33000046/following/">Follow</a></li></ul>
+
+
+
+
+				<div class="character__content selected">
+
+
+					<div class="heading__flex"><h3>Profile</h3><span class="heading__flex__text">Display Attributes</span><input class="character__tgl" id="toggle-profile" type="checkbox" disabled><label class="character__tgl-btn js__tooltip" for="toggle-profile" data-tooltip="Show Attributes" data-parameter_off="Show Attributes" data-parameter_on="Hide Attributes"></label></div><div class="character__profile clearfix"><div class="character__profile__data"><div class="js__character_toggle"><div class="character__profile__data__detail"><div class="character-block"><img src="https://img2.finalfantasyxiv.com/f/197341aa090981d3cf179d2703eb85bc_284358f8eb4efc9095914e46798c6ab3fc0_96x96.jpg?1642763759" width="32" height="32" alt="" class="character-block__face"><div class="character-block__box"><p class="character-block__title">Race/Clan/Gender</p><p class="character-block__name">Miqo&#39;te<br />Seeker of the Sun / ♂</p></div></div><div class="character-block"><img src="https://img.finalfantasyxiv.com/lds/h/D/IaeQ866z-QseoMBt5GJFKtq9MM.png" width="32" height="32" alt=""><div class="character-block__box"><p class="character-block__title">Nameday</p><p class="character-block__birth">20th Sun of the 6th Umbral Moon</p><p class="character-block__title">Guardian</p><p class="character-block__name">Althyk, the Keeper</p></div></div><div class="character-block"><img src="https://img.finalfantasyxiv.com/lds/h/u/qXfC-BmEzWbXW3sn62HMNnD3kU.png" width="32" height="32" alt=""><div class="character-block__box"><p class="character-block__title">City-state</p><p class="character-block__name">Ul&#39;dah</p></div></div><div class="character-block"><img src="https://img.finalfantasyxiv.com/lds/h/e/5tZ-HAT8T1OqiGYCsb_vqbrFOM.png" width="32" height="32" alt=""><div class="character-block__box"><p class="character-block__title">Grand Company</p><p class="character-block__name">Order of the Twin Adder / Serpent Private Third Class</p></div></div></div></div><div class="js__character_toggle hide"><h3 class="heading--lead"><i class="icon-c--title icon-c__attributes"></i>Attributes</h3><table class="character__param__list"><tr><th><span class="js__tooltip" data-tooltip="Affects physical damage dealt by gladiator's arms, marauder's arms, pugilist's arms, lancer's arms, conjurer's arms, thaumaturge's arms, arcanist's arms, dark knight's arms, samurai's arms, reaper's arms, gunbreaker's arms, red mage's arms, astrologian's arms, sage's arms, and blue mage's arms.">Strength</span></th><td>182</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects physical ranged damage and damage dealt by rogue's arms.">Dexterity</span></th><td>171</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects maximum HP.">Vitality</span></th><td>168</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects attack magic potency when role is DPS.">Intelligence</span></th><td>75</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects healing magic potency. Also affects attack magic potency when role is Healer.">Mind</span></th><td>131</td></tr></table><h3 class="heading--lead"><i class="icon-c--title icon-c__offense"></i>Offensive Properties</h3><table class="character__param__list"><tr><th><span class="js__tooltip" data-tooltip="Affects the amount of physical and magic damage dealt, as well as HP restored. The higher the value, the higher the frequency with which your hits will be critical/higher the potency of critical hits.">Critical Hit Rate</span></th><td>239</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects the amount of damage dealt by both physical and magic attacks, as well as the amount of HP restored by healing spells.">Determination</span></th><td>148</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects the rate at which your physical and magic attacks land direct hits, slightly dealing more damage than normal hits. The higher the value, the higher the frequency with which your hits will be direct.">Direct Hit Rate</span></th><td>249</td></tr></table><h3 class="heading--lead"><i class="icon-c--title icon-c__deffense"></i>Defensive Properties</h3><table class="character__param__list"><tr><th><span class="js__tooltip" data-tooltip="Affects the amount of damage taken by physical attacks. The higher the value, the less damage taken.">Defense</span></th><td>245</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects the amount of damage taken by magic attacks. The higher the value, the less damage taken.">Magic Defense</span></th><td>245</td></tr></table><h3 class="heading--lead"><i class="icon-c--title icon-c__melle"></i>Physical Properties</h3><table class="character__param__list"><tr><th><span class="js__tooltip" data-tooltip="Affects amount of damage dealt by physical attacks. The higher the value, the more damage dealt.">Attack Power</span></th><td>182</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects both the casting and recast timers, as well as the damage over time potency for weaponskills and auto-attacks. The higher the value, the shorter the timers/higher the potency.">Skill Speed</span></th><td>243</td></tr></table><h3 class="heading--lead"><i class="icon-c--title icon-c__spell"></i>Mental Properties</h3><table class="character__param__list"><tr><th><span class="js__tooltip" data-tooltip="Affects the amount of damage dealt by magic attacks.">Attack Magic Potency</span></th><td>75</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects the amount of HP restored via healing magic.">Healing Magic Potency</span></th><td>131</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects both the casting and recast timers for spells. The higher the value, the shorter the timers. Also affects a spell's damage over time or healing over time potency.">Spell Speed</span></th><td>236</td></tr></table><h3 class="heading--lead"><i class="icon-c--title icon-c__role"></i>Role</h3><table class="character__param__list"><tr><th><span class="js__tooltip" data-tooltip="Affects the amount of physical and magic damage dealt and received, as well as HP restored. The higher the value, the more damage dealt, the more HP restored, and the less damage taken. Only applicable when role is Tank.">Tenacity</span></th><td>236</td></tr><tr><th class="pb-0"><span class="js__tooltip" data-tooltip="Affects MP regeneration. Regeneration rate is determined by piety. Only applicable when in battle and role is Healer.">Piety</span></th><td class="pb-0">139</td></tr></table></div></div><div class="character__profile__detail"><div class="character__view clearfix"><div class="character__class"><div class="character__class__arms"><div class="icon-c--0 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/14/141c47b807c0e8d9cbd6a858fbd1443c9805aaef.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/07/0782c9af2f1dc44867197012732c021966a590ec.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Steel Claws</h2><p class="db-tooltip__item__category">Pugilist&#39;s Arm</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/ad026fa210b/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 29</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name">Physical Damage</div><div class="db-tooltip__item_spec__name">Auto-attack</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Delay</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value"><strong class="">31</strong></div><div class="db-tooltip__item_spec__value"><strong class="">26.45</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">2.56</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">PGL MNK</div><div class="db-tooltip__item_equipment__level">Lv. 29</div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Strength</span> +5</li><li class=""><span>Vitality</span> +6</li><li class=""><span>Skill Speed</span> +7</li></ul><h3 class="db-tooltip__sub_title">Materia</h3><hr class="db-tooltip__line"><ul class="db-tooltip__materia"><li class="clearfix db-tooltip__materia__normal"><div class="socket">&nbsp;</div></li><li class="clearfix db-tooltip__materia__normal"><div class="socket">&nbsp;</div></li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Blacksmith Lv. 19</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 3 Dark Matter</span></li><li><span class="db-tooltip__item_repair__title">Materia Melding</span><span>Blacksmith Lv. 29</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>29.00</span></li><li>Dyeable: <span>No</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Steel%20Claws%22">3,586 gil</a></p><span><span class="db-tooltip__sells">Sells for </span>41 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div></div><div class="character__class__data"><p>LEVEL 39 </p><div class="character__class_icon"><img src="https://img.finalfantasyxiv.com/lds/h/K/HW6tKOg4SOJbL8Z20GnsAWNjjM.png" width="24" height="24" alt=""></div><img src="https://img.finalfantasyxiv.com/lds/h/I/-FYU8hC0lIOJPGa_Di0O8ntJF8.png" width="266" height="28" alt="" class="character__classjob"></div></div><div class="character__detail"><div class="character__detail__icon"><div class="icon-c--2 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/7d/7dba65dcb7684999378a6b5e8e4b14c89d668564.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="staining" style="background: #3b4d3c;"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><div class="staining" style="background: #3b4d3c;"></div><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/88/885fddcc97a71b95783ccd72c9278a7fa07a2c83.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/h/iMiPYBWuh22FtFJTn2coPIp0I0.png" width="20" height="20" class="js__tooltip" alt="Can have company crests applied." data-tooltip="Can have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Altered Velveteen Bandana</h2><p class="db-tooltip__item__category">Head</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/fc420c76c9f/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 25</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">46</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">46</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">Disciple of War</div><div class="db-tooltip__item_equipment__level">Lv. 25</div></div><hr class="db-tooltip__line"><div class="list_1col eorzeadb_tooltip_mb10"><div class="stain"><a href="/lodestone/playguide/db/item/996f0ac6809/">Nophica Green Dye</a></div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Strength</span> +3</li><li class=""><span>Dexterity</span> +3</li><li class=""><span>Vitality</span> +3</li><li class=""><span>Determination</span> +4</li></ul><h3 class="db-tooltip__sub_title">Materia</h3><hr class="db-tooltip__line"><ul class="db-tooltip__materia"><li class="clearfix db-tooltip__materia__normal"><div class="socket">&nbsp;</div></li><li class="clearfix db-tooltip__materia__normal"><div class="socket">&nbsp;</div></li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Weaver Lv. 15</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 3 Dark Matter</span></li><li><span class="db-tooltip__item_repair__title">Materia Melding</span><span>Weaver Lv. 25</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>25.00</span></li><li>Dyeable: <span>Yes</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Available for Purchase: </span>No</p><span><span class="db-tooltip__sells">Sells for </span>16 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--3 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/0b/0bc21dbee71b2a8142698b41b2e87cbfc1666aa1.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="staining" style="background: #1a1f27;"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><div class="staining" style="background: #1a1f27;"></div><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/9c/9ce3507a533f58293c1acb2d48c861dc087bfbb2.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/h/iMiPYBWuh22FtFJTn2coPIp0I0.png" width="20" height="20" class="js__tooltip" alt="Can have company crests applied." data-tooltip="Can have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Toadskin Jacket</h2><p class="db-tooltip__item__category">Body</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/e30fd16688b/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 30</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">74</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">74</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">Disciple of War</div><div class="db-tooltip__item_equipment__level">Lv. 30</div></div><hr class="db-tooltip__line"><div class="list_1col eorzeadb_tooltip_mb10"><div class="stain"><a href="/lodestone/playguide/db/item/9ef01a4f17f/">Ink Blue Dye</a></div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Strength</span> +5</li><li class=""><span>Dexterity</span> +5</li><li class=""><span>Vitality</span> +6</li><li class=""><span>Direct Hit Rate</span> +7</li></ul><h3 class="db-tooltip__sub_title">Materia</h3><hr class="db-tooltip__line"><ul class="db-tooltip__materia"><li class="clearfix db-tooltip__materia__normal"><div class="socket">&nbsp;</div></li><li class="clearfix db-tooltip__materia__normal"><div class="socket">&nbsp;</div></li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Leatherworker Lv. 20</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 3 Dark Matter</span></li><li><span class="db-tooltip__item_repair__title">Materia Melding</span><span>Leatherworker Lv. 30</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>30.00</span></li><li>Dyeable: <span>Yes</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Toadskin%20Jacket%22">3,123 gil</a></p><span><span class="db-tooltip__sells">Sells for </span>41 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--4 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/a5/a594f078ebd6907a3a656034d4ff150993d053d6.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/05/05ec407f1a51dd3a76d73e01a1f47bfb7db10f2e.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><span class="rare">Unique</span><span class="ex_bind">Untradable</span><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Brand-new Gloves</h2><p class="db-tooltip__item__category">Hands</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/7f50b16ac0b/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 17</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">37</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">37</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">Disciple of War</div><div class="db-tooltip__item_equipment__level">Lv. 15</div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Strength</span> +2</li><li class=""><span>Dexterity</span> +2</li><li class=""><span>Vitality</span> +2</li><li class=""><span>Determination</span> +1</li><li class=""><span>Direct Hit Rate</span> +2</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Leatherworker Lv. 5</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 2 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>No</span></li><li>Dyeable: <span>No</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Available for Purchase: </span>No</p><span class="db-view__unsellable"><span class="db-tooltip__unsellable">Unsellable</span></span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--6 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/4e/4e30444f0eec71632453f549e81f98cb562e5246.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/84/840920520898af9e59da5626a681ec0d8d07906c.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><span class="rare">Unique</span><span class="ex_bind">Untradable</span><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Brand-new Skirt</h2><p class="db-tooltip__item__category">Legs</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/4670ef7f755/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 17</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">49</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">49</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">Disciple of War</div><div class="db-tooltip__item_equipment__level">Lv. 15</div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Strength</span> +3</li><li class=""><span>Dexterity</span> +3</li><li class=""><span>Vitality</span> +3</li><li class=""><span>Determination</span> +2</li><li class=""><span>Direct Hit Rate</span> +3</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Weaver Lv. 5</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 2 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>No</span></li><li>Dyeable: <span>No</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Available for Purchase: </span>No</p><span class="db-view__unsellable"><span class="db-tooltip__unsellable">Unsellable</span></span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--7 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/c6/c6374b3f20143499e4a1d4a50df8e03f550bbc9a.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/7c/7c0f60a3885c0ca98116c4e56b006bd5b879869d.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><span class="rare">Unique</span><span class="ex_bind">Untradable</span><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Brand-new Boots</h2><p class="db-tooltip__item__category">Feet</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/677fa1f05a2/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 17</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">37</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">37</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">Disciple of War</div><div class="db-tooltip__item_equipment__level">Lv. 15</div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Strength</span> +2</li><li class=""><span>Dexterity</span> +2</li><li class=""><span>Vitality</span> +2</li><li class=""><span>Critical Hit</span> +2</li><li class=""><span>Determination</span> +1</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Leatherworker Lv. 5</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 2 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>No</span></li><li>Dyeable: <span>No</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Available for Purchase: </span>No</p><span class="db-view__unsellable"><span class="db-tooltip__unsellable">Unsellable</span></span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div></div><div class="character__detail__image"><a href="https://img2.finalfantasyxiv.com/f/197341aa090981d3cf179d2703eb85bc_284358f8eb4efc9095914e46798c6ab3fl0_640x873.jpg?1642763759" class="js__image_popup"><img src="https://img2.finalfantasyxiv.com/f/197341aa090981d3cf179d2703eb85bc_284358f8eb4efc9095914e46798c6ab3fl0_640x873.jpg?1642763759" width="220" height="300" alt=""><img src="https://img.finalfantasyxiv.com/lds/h/U/ufiv3TIMncKieVNZc8xRk2ski0.png" width="32" height="32" class="character__detail__popup js__tooltip" data-tooltip="Enlarge Character Portrait "></a></div><div class="character__detail__icon"><div class="icon-c--1 ic_reflection_box js__db_tooltip"></div><div class="icon-c--8 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/6f/6fa193744637a6d1e7fea1bccbb4ea3d2e7144fd.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/6c/6c12667efbb64fd22d7971f9534f9d8b31680b27.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Weathered Earrings</h2><p class="db-tooltip__item__category">Earrings</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/18edb75b865/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 5</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">0</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">0</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">All Classes</div><div class="db-tooltip__item_equipment__level">Lv. 1</div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Strength</span> +1</li><li class=""><span>Dexterity</span> +1</li><li class=""><span>Vitality</span> +1</li><li class=""><span>Intelligence</span> +1</li><li class=""><span>Mind</span> +1</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Goldsmith Lv. 1</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 1 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>No</span></li><li>Dyeable: <span>No</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Weathered%20Earrings%22">168 gil</a></p><span><span class="db-tooltip__sells">Sells for </span>2 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--9 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/48/48edecc6cc48d8c6a822b9f01462f2176c00568c.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/90/9018f8765717070b1f46318abbc0279ff5b0dc26.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><span class="ex_bind">Untradable</span><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_magic">Aetherial Brass Gorget</h2><p class="db-tooltip__item__category">Necklace</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/c9a48ecf114/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 16</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">1</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">1</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">All Classes</div><div class="db-tooltip__item_equipment__level">Lv. 15</div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Strength</span> +1</li><li class=""><span>Dexterity</span> +1</li><li class=""><span>Vitality</span> +1</li><li class=""><span>Critical Hit</span> +1</li><li class=""><span>Determination</span> +1</li><li class=""><span>Direct Hit Rate</span> +1</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Goldsmith Lv. 5</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 2 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>16.00</span></li><li>Dyeable: <span>No</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Available for Purchase: </span>No</p><span><span class="db-tooltip__sells">Sells for </span>4 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--10 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/30/3045fdb81024b76b4125b23bc2ca9385d4b90d8a.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/73/733e40aae1563451475daf8edd86212eef682777.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><span class="rare">Unique</span><span class="ex_bind">Untradable</span><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Dawn Wristguards</h2><p class="db-tooltip__item__category">Bracelets</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/b818ddc9ac9/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 18</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">0</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">0</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">All Classes</div><div class="db-tooltip__item_equipment__level">Lv. 18</div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Strength</span> +2</li><li class=""><span>Dexterity</span> +2</li><li class=""><span>Vitality</span> +1</li><li class=""><span>Intelligence</span> +2</li><li class=""><span>Mind</span> +2</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Leatherworker Lv. 8</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 2 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>No</span></li><li>Dyeable: <span>No</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Dawn%20Wristguards%22">100 gil (Restricted)</a></p><span class="db-view__unsellable"><span class="db-tooltip__unsellable">Unsellable</span></span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--11 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/09/0950bfc475fcb5a935280781078e17c3160175fe.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/1b/1b0a5f8821caca4dc615a2c772527fae120aba18.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><span class="rare">Unique</span><span class="ex_bind">Untradable</span><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Brand-new Ring</h2><p class="db-tooltip__item__category">Ring</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/213fc7a1359/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 30</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">1</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">1</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">Disciples of War or Magic</div><div class="db-tooltip__item_equipment__level">Lv. 1</div></div><hr class="db-tooltip__line"><div class="db-tooltip__help_text">Increases EXP earned by 30% when level 30 and below.</div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Strength</span> +3</li><li class=""><span>Dexterity</span> +3</li><li class=""><span>Vitality</span> +3</li><li class=""><span>Intelligence</span> +3</li><li class=""><span>Mind</span> +3</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Goldsmith Lv. 1</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 1 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>No</span></li><li>Dyeable: <span>No</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Available for Purchase: </span>No</p><span class="db-view__unsellable"><span class="db-tooltip__unsellable">Unsellable</span></span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--12 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/77/77a2a6cfa9232761cb77fbf383beac9aeb9314ae.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/19/1941591b5bd246e071d2521b73100c07069495bc.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Weathered Ring</h2><p class="db-tooltip__item__category">Ring</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/80ab609c7cf/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 5</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">0</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">0</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">All Classes</div><div class="db-tooltip__item_equipment__level">Lv. 1</div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Strength</span> +1</li><li class=""><span>Dexterity</span> +1</li><li class=""><span>Vitality</span> +1</li><li class=""><span>Intelligence</span> +1</li><li class=""><span>Mind</span> +1</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Goldsmith Lv. 1</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 1 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>No</span></li><li>Dyeable: <span>No</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Weathered%20Ring%22">168 gil</a></p><span><span class="db-tooltip__sells">Sells for </span>2 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--13 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/41/412323f41c51d36ac2182f6956196f510bf82554.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/c1/c169ae652ae409c360b9196b87000c41e85214ff.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><span class="rare">Unique</span><span class="ex_bind">Untradable</span><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/w/bYicY0UQPnsG5cFAQClqLocfMw.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in a glamour dresser." data-tooltip="Cannot be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Soul of the Monk</h2><p class="db-tooltip__item__category">Soul Crystal</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/a03321484cc/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 30</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"></div><div class="clearfix"></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">PGL MNK</div><div class="db-tooltip__item_equipment__level">Lv. 30</div></div><hr class="db-tooltip__line"><div class="db-tooltip__help_text">Upon the surface of this multi-aspected crystal are carved the myriad deeds of monks from eras past.</div></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Available for Purchase: </span>No</p><span class="db-view__unsellable"><span class="db-tooltip__unsellable">Unsellable</span></span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div></div></div></div><div class="js__character_toggle"><div class="character__level clearfix"><div class="character__level__list"><ul><li><img src="https://img.finalfantasyxiv.com/lds/h/U/F5JzG9RPIKFSogtaKNBk455aYA.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Gladiator">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/N/St9rjDJB3xNKGYg-vwooZ4j6CM.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Marauder">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/l/5CZEvDOMYMyVn2td9LZigsgw9s.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Dark Knight">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/8/hg8ofSSOKzqng290No55trV4mI.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Gunbreaker">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/s/gl62VOTBJrm7D_BmAZITngUEM8.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Conjurer">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/7/WdFey0jyHn9Nnt1Qnm-J3yTg5s.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Scholar">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/1/erCgjnMSiab4LiHpWxVc-tXAqk.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Astrologian">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/g/_oYApASVVReLLmsokuCJGkEpk0.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Sage">-</li></ul></div></div><div class="character__level clearfix"><div class="character__level__list"><ul><li><img src="https://img.finalfantasyxiv.com/lds/h/K/HW6tKOg4SOJbL8Z20GnsAWNjjM.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Monk / Pugilist">39</li><li><img src="https://img.finalfantasyxiv.com/lds/h/k/tYTpoSwFLuGYGDJMff8GEFuDQs.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Lancer">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/y/wdwVVcptybfgSruoh8R344y_GA.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Rogue">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/m/KndG72XtCFwaq1I1iqwcmO_0zc.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Samurai">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/7/cLlXUaeMPJDM2nBhIeM-uDmPzM.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Reaper">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/Q/ZpqEJWYHj9SvHGuV9cIyRNnIkk.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Archer">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/E/vmtbIlf6Uv8rVp2YFCWA25X0dc.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Machinist">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/t/HK0jQ1y7YV9qm30cxGOVev6Cck.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Dancer">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/4/IM3PoP6p06GqEyReygdhZNh7fU.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Thaumaturge">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/e/VYP1LKTDpt8uJVvUT7OKrXNL9E.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Arcanist">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/q/s3MlLUKmRAHy0pH57PnFStHmIw.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Red Mage">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/p/jdV3RRKtWzgo226CC09vjen5sk.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Blue Mage (Limited Job)">-</li></ul></div></div><div class="character__level clearfix"><div class="character__level__list"><ul><li><img src="https://img.finalfantasyxiv.com/lds/h/v/YCN6F-xiXf03Ts3pXoBihh2OBk.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Carpenter">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/EEHVV5cIPkOZ6v5ALaoN5XSVRU.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Blacksmith">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/G/Rq5wcK3IPEaAB8N-T9l6tBPxCY.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Armorer">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/L/LbEjgw0cwO_2gQSmhta9z03pjM.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Goldsmith">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/b/ACAcQe3hWFxbWRVPqxKj_MzDiY.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Leatherworker">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/X/E69jrsOMGFvFpCX87F5wqgT_Vo.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Weaver">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/C/bBVQ9IFeXqjEdpuIxmKvSkqalE.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Alchemist">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/m/1kMI2v_KEVgo30RFvdFCyySkFo.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Culinarian">-</li></ul></div></div><div class="character__level clearfix"><div class="character__level__list"><ul><li><img src="https://img.finalfantasyxiv.com/lds/h/A/aM2Dd6Vo4HW_UGasK7tLuZ6fu4.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Miner">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/I/jGRnjIlwWridqM-mIPNew6bhHM.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Botanist">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/x/B4Azydbn7Prubxt7OL9p1LZXZ0.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Fisher">-</li></ul></div></div></div><div class="js__character_toggle hide"><div class="character__param"><ul><li><div><p class="character__param__text character__param__text__hp--en-gb">HP</p><span>1209</span></div><i class="character__param--hp"></i></li><li><div><p class="character__param__text character__param__text__mp--en-gb">MP</p><span>10000</span></div><i class="character__param--mp"></i></li></ul></div></div></div></div><div class="heading__icon parts__space--reset"><h3>Character Profile</h3></div><div class="character__selfintroduction">-</div>
+
+
+					<div class="btn__comment">
+
+
+					</div>
+
+
+
+
+
+					<ul class="social__btn"><li><a href="http://www.facebook.com/share.php?u=https://eu.finalfantasyxiv.com/lodestone/character/33000046" target="_blank"><i class="xiv-lds xiv-lds-facebook js__tooltip" data-tooltip="Share"></i></a></li><li><a href="https://twitter.com/share?url=https://eu.finalfantasyxiv.com/lodestone/character/33000046&text=K%27ewl%20D%27eeps%20%7C%20FINAL%20FANTASY%20XIV%2C%20The%20Lodestone" target="_blank"><i class="xiv-lds xiv-lds-twitter js__tooltip" data-tooltip="Tweet"></i></a></li></ul>
+
+				</div>
+
+				<div class="character__content"></div><div class="character__content"></div><div class="character__content"></div><div class="character__content"></div>
+			</div>
+		</div>
+
+		<div class="ldst__side">
+
+
+
+
+			<div class="l__rside__bnr clearfix">
+				<a href="https://forum.square-enix.com/ffxiv/forum.php?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_forum" target="_blank" class="l__rside__bnr--forums"><img src="https://img.finalfantasyxiv.com/lds/h/i/i3r6u3moBzQFfijSTu9k3EJirQ.png" width="100" height="62" alt="Forums"></a><a href="https://sqex.to/Msp?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_mogstation" target="_blank" class="l__rside__bnr--mog_station"><img src="https://img.finalfantasyxiv.com/lds/h/3/GjsnqfVxPQrE4Jve8GvKZABF5w.png" width="100" height="62" alt="Mog Station"></a><a href="/pr/blog/?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_officalblog" target="_blank" class="l__rside__bnr--blog"><img src="https://img.finalfantasyxiv.com/lds/h/d/nVeXvIIStLv3npokivV0EzkKwI.png" width="100" height="62" alt="Official Blog"></a>
+			</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+			<div class="mb10"><a href="/endwalker/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_endwalker"><img src="https://img.finalfantasyxiv.com/lds/banner/998/v60_211207_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="https://store.finalfantasyxiv.com/ffxivstore/en-gb/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_onlinestore" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/banner/916/LDS_ffxivos_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/special/2022/All_Saints_Wake/rjk7wevhuy?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_all_saints_wake"><img src="https://img.finalfantasyxiv.com/lds/banner/1119/mnbn_all_saints_wake-1_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/community_finder/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_cf202112"><img src="https://img.finalfantasyxiv.com/lds/banner/1104/LDS_CF_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/jobguide/battle/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_jobguide"><img src="https://img.finalfantasyxiv.com/lds/banner/1089/jobguide_v60_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/uiguide/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_uiguide"><img src="https://img.finalfantasyxiv.com/lds/banner/671/pc_uiguide_eu.jpg"></a></div>
+
+
+
+			<div class="conducting_area">
+
+				<img src="https://img.finalfantasyxiv.com/lds/h/z/EhLfs3eya3Aidfr8A6PbXOBgtA.png" width="300" height="218" alt="">
+
+				<div class="inr">
+					<a href="
+				http://freetrial.finalfantasyxiv.com/" class="bt_conducting">
+						<img src="https://img.finalfantasyxiv.com/lds/h/s/3KRua4vzZJvRXn0IMk8Da103bw.png" width="284" height="80" alt="Start Your Free Trial">
+					</a>
+					<a href="/product/?utm_source=lodestone&utm_medium=pc_buyarea&utm_campaign=eu_buynow" class="bt_conducting" target="_blank">
+						<img src="https://img.finalfantasyxiv.com/lds/h/p/to8CzK_gktAHpLuSGzCkNdLfWo.png" width="284" height="80" alt="BUY NOW!">
+					</a>			<a href="https://support.eu.square-enix.com/faqarticle.php?id=5383&la=2&kid=78775" onmousedown="ga('send', 'event', 'lodestone_eu', 'howtoupgrade_link', 'EU-lodestone-UG_20170620', true);" class="bt_ft_migration">			<img src="https://img.finalfantasyxiv.com/lds/h/0/5rrJdYAcP3if6zX6d62dHV3t34.png" width="260" height="80" alt="Upgrade Your Free Trial<br />to the Full Version">
+				</a>
+				</div>
+			</div>
+
+
+
+
+
+
+
+
+
+			<div class="mb10"><a href="/tales_of_adventure/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_tales_of_adventure"><img src="https://img.finalfantasyxiv.com/lds/banner/1079/LDS_Tales_of_Adventure_v60_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/special/friend_recruit/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_friendrecruit"><img src="https://img.finalfantasyxiv.com/lds/banner/203/bn_Recruit_a_Friend_eu.png"></a></div>
+
+
+
+
+
+
+			<div class="ldst__side__box">
+
+
+
+				<div class="heading--side">
+					<h3>Community Wall</h3>
+					<a href="/lodestone/community/" class="heading--side__icon icon-list__side js__tooltip" data-tooltip="See More"></a>
+				</div>
+				<div class="heading__icon parts__space--reset js__toggle_wrapper">
+					<h4>Recent Activity</h4>
+					<i class="icon-btn__filter js__toggle_trigger js__tooltip" data-tooltip="Filter"></i>
+					<div class="parts__switch parts__switch--filter js__toggle_item">
+						<p class="parts__text">
+							Filter which items are to be displayed below.<br>
+							<span class="parts__text__notes">
+				* Notifications for standings updates are shared across all Worlds.<br>
+				* Notifications for PvP team formations are shared for all languages.<br>
+				* Notifications for free company formations are shared for all languages.
+			</span>
+						</p>
+
+
+						<div class="form__horizontal js__communitywall_filter">
+							<input type="hidden" name="order" value=""><h5 class="heading--side--lead">Sort by</h5><ul class="form__row parts__spce--8"><li><input type="checkbox" name="community_type" value="blog" class="form__checkbox" id="community_type01"><label class="form__checkbox__label" for="community_type01">Blog</label></li><li><input type="checkbox" name="community_type" value="event" class="form__checkbox" id="community_type02"><label class="form__checkbox__label" for="community_type02">Event & Party Recruitment</label></li><li><input type="checkbox" name="community_type" value="fc" class="form__checkbox" id="community_type03"><label class="form__checkbox__label" for="community_type03">Free Company</label></li><li><input type="checkbox" name="community_type" value="db" class="form__checkbox" id="community_type04"><label class="form__checkbox__label" for="community_type04">Eorzea Database</label></li><li><input type="checkbox" name="community_type" value="ranking" class="form__checkbox" id="community_type05"><label class="form__checkbox__label" for="community_type05">Standings</label></li><li><input type="checkbox" name="community_type" value="pvpteam" class="form__checkbox" id="community_type06"><label class="form__checkbox__label" for="community_type06">PvP Team</label></li><li><input type="checkbox" name="community_type" value="community_finder" class="form__checkbox" id="community_type07"><label class="form__checkbox__label" for="community_type07">Community Finder</label></li></ul><h5 class="heading--side--lead">Data Center / Home World</h5><div class="select-pulldown"><label class="control-label" for="world"></label><select name="community_worldname" class="select-pulldown__open"><option value="">Select All</option><optgroup label="Data Center"><option value="_dc_Elemental">Elemental</option><option value="_dc_Gaia">Gaia</option><option value="_dc_Mana">Mana</option><option value="_dc_Aether">Aether</option><option value="_dc_Primal">Primal</option><option value="_dc_Crystal">Crystal</option><option value="_dc_Chaos">Chaos</option><option value="_dc_Light">Light</option></optgroup><optgroup label="Home World"><option value="Adamantoise">Adamantoise</option><option value="Aegis">Aegis</option><option value="Alexander">Alexander</option><option value="Anima">Anima</option><option value="Asura">Asura</option><option value="Atomos">Atomos</option><option value="Bahamut">Bahamut</option><option value="Balmung">Balmung</option><option value="Behemoth">Behemoth</option><option value="Belias">Belias</option><option value="Brynhildr">Brynhildr</option><option value="Cactuar">Cactuar</option><option value="Carbuncle">Carbuncle</option><option value="Cerberus">Cerberus</option><option value="Chocobo">Chocobo</option><option value="Coeurl">Coeurl</option><option value="Diabolos">Diabolos</option><option value="Durandal">Durandal</option><option value="Excalibur">Excalibur</option><option value="Exodus">Exodus</option><option value="Faerie">Faerie</option><option value="Famfrit">Famfrit</option><option value="Fenrir">Fenrir</option><option value="Garuda">Garuda</option><option value="Gilgamesh">Gilgamesh</option><option value="Goblin">Goblin</option><option value="Gungnir">Gungnir</option><option value="Hades">Hades</option><option value="Hyperion">Hyperion</option><option value="Ifrit">Ifrit</option><option value="Ixion">Ixion</option><option value="Jenova">Jenova</option><option value="Kujata">Kujata</option><option value="Lamia">Lamia</option><option value="Leviathan">Leviathan</option><option value="Lich">Lich</option><option value="Louisoix">Louisoix</option><option value="Malboro">Malboro</option><option value="Mandragora">Mandragora</option><option value="Masamune">Masamune</option><option value="Mateus">Mateus</option><option value="Midgardsormr">Midgardsormr</option><option value="Moogle">Moogle</option><option value="Odin">Odin</option><option value="Omega">Omega</option><option value="Pandaemonium">Pandaemonium</option><option value="Phoenix">Phoenix</option><option value="Ragnarok">Ragnarok</option><option value="Ramuh">Ramuh</option><option value="Ridill">Ridill</option><option value="Sargatanas">Sargatanas</option><option value="Shinryu">Shinryu</option><option value="Shiva">Shiva</option><option value="Siren">Siren</option><option value="Spriggan">Spriggan</option><option value="Tiamat">Tiamat</option><option value="Titan">Titan</option><option value="Tonberry">Tonberry</option><option value="Twintania">Twintania</option><option value="Typhon">Typhon</option><option value="Ultima">Ultima</option><option value="Ultros">Ultros</option><option value="Unicorn">Unicorn</option><option value="Valefor">Valefor</option><option value="Yojimbo">Yojimbo</option><option value="Zalera">Zalera</option><option value="Zeromus">Zeromus</option><option value="Zodiark">Zodiark</option></optgroup></select></div><h5 class="heading--side--lead">Primary language</h5><div class="select-pulldown"><label class="control-label" for="lang"></label><select name="community_lang" class="select-pulldown__open"><option value="">Select All</option><option value="ja">Japanese</option><option value="en">English</option><option value="de">German</option><option value="fr">French</option></select></div><h5 class="heading--side--lead">Displaying</h5><div class="select-pulldown"><label class="control-label" for="limit"></label><select name="community_limit" class="select-pulldown__open"><option value="10">10</option><option value="20">20</option><option value="30">30</option></select></div><div class="form__submit form__submit--full"><input type="submit" value="Filter" class="js__bt_communitywall_filter"></div>
+						</div>
+
+
+					</div>
+				</div>
+
+
+				<ul class="side__list__box">
+
+
+					<div class="entry more_"><a href="/lodestone/character/21923792/blog/4942246/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-fa6dd57b41e" class="datetime_dynamic_ymdhm" data-epoch="1642765271">-</span><script>document.getElementById('datetime-fa6dd57b41e').innerHTML = ldst_strftime_dynamic_ymdhm(1642765271);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Moko-steller Herzton</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ifrit&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Moko-steller Herzton (<i class="xiv-lds xiv-lds-home-world"></i>Ifrit) posted a new blog entry, "辺獄編クリアした感想."</p></div></div></div></a><a href="/lodestone/character/21923792/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/4d2543fd4ac79776e528bdfb9183a801_f9f796348bc43067c7242ec4551cde69fc0_96x96.jpg?1642762509" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/freecompany/9236882835737018846/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header--common clearfix"><time class="entry__activity__time"><span id="datetime-fdb27bc7b6a" class="datetime_dynamic_ymdhm" data-epoch="1642765249">-</span><script>document.getElementById('datetime-fdb27bc7b6a').innerHTML = ldst_strftime_dynamic_ymdhm(1642765249);</script></time></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__fc js__tooltip"data-tooltip="Free Company"></span></div><div class="entry__activity__txt--message"><p>HanaBank (Masamune) has been formed.</p></div></div></div></a><div class="entry__activity__link"><img src="https://img.finalfantasyxiv.com/lds/h/9/_Huf58epDlt9vXiO8IIfPXxtXI.png" width="50" height="50" alt=""></div></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/29420884/blog/4942243/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-2f50a2f46fa" class="datetime_dynamic_ymdhm" data-epoch="1642765009">-</span><script>document.getElementById('datetime-2f50a2f46fa').innerHTML = ldst_strftime_dynamic_ymdhm(1642765009);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Charis Prmeria</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Garuda&nbsp;(Elemental)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Charis Prmeria (<i class="xiv-lds xiv-lds-home-world"></i>Garuda) posted a new blog entry, "★Garuda★ FCメンバー募集中！."</p></div></div></div></a><a href="/lodestone/character/29420884/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/3e068e8db1635bcc48ce4583c3bd57ef_fcb1f5b0249d1069e5bdc66d0796f26afc0_96x96.jpg?1642762064" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/community_finder/5a97f8a127ca89d8fa9190c94babc23b253d1753/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-93fe5e72fab" class="datetime_dynamic_ymdhm" data-epoch="1642764812">-</span><script>document.getElementById('datetime-93fe5e72fab').innerHTML = ldst_strftime_dynamic_ymdhm(1642764812);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Sayuri Kuroyuki</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Cerberus&nbsp;(Chaos)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__community_finder js__tooltip"data-tooltip="Community Finder"></span></div><div class="entry__activity__txt--message"><p>Sayuri Kuroyuki (<i class="xiv-lds xiv-lds-home-world"></i>Cerberus) has started recruitment for the free company "No Solution (Cerberus)."</p></div></div></div></a><a href="/lodestone/character/9018393/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/bd14d70b0db26821b02b799bb4fd9f46_777c57311d510ca65dac3c1077dee435fc0_96x96.jpg?1642763258" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/22234/blog/4941345/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-de144b683dc" class="datetime_dynamic_ymdhm" data-epoch="1642764696">-</span><script>document.getElementById('datetime-de144b683dc').innerHTML = ldst_strftime_dynamic_ymdhm(1642764696);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Wao Miqotte</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Aegis&nbsp;(Elemental)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Wao Miqotte (<i class="xiv-lds xiv-lds-home-world"></i>Aegis) posted a new blog entry, "Lv83 インペリアル・ストライカー装備「ミコちゃんに叱られる！」ミラプリっ‼︎."</p></div></div></div></a><a href="/lodestone/character/22234/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/19bf3a0dfa9eadd8da9619ac17dbd99a_3ea38e723c590aabf186367e1eb7e6a1fc0_96x96.jpg?1642763835" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/41253362/blog/4942240/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-64ca6268a6e" class="datetime_dynamic_ymdhm" data-epoch="1642764544">-</span><script>document.getElementById('datetime-64ca6268a6e').innerHTML = ldst_strftime_dynamic_ymdhm(1642764544);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Jana Noe</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ultima&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Jana Noe (<i class="xiv-lds xiv-lds-home-world"></i>Ultima) posted a new blog entry, "一筋縄ではいかない守護天節."</p></div></div></div></a><a href="/lodestone/character/41253362/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/99b7cec774fcf1265e0c5cb067009ed1_9df1b3cb0da35db33c17ef11ddf12adafc0_96x96.jpg?1642765402" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/32506355/blog/4942239/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-a0edb51991c" class="datetime_dynamic_ymdhm" data-epoch="1642764507">-</span><script>document.getElementById('datetime-a0edb51991c').innerHTML = ldst_strftime_dynamic_ymdhm(1642764507);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Yuki Sternen</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ramuh&nbsp;(Elemental)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Yuki Sternen (<i class="xiv-lds xiv-lds-home-world"></i>Ramuh) posted a new blog entry, "豪華な夕食（及びサーバ移転のご報告）."</p></div></div></div></a><a href="/lodestone/character/32506355/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/a46765e58b325824f76a243b51483548_410ddb5a66a2fcacf538bec5ea5d0291fc0_96x96.jpg?1642761957" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/4060849/blog/4942237/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-30ae3c1479e" class="datetime_dynamic_ymdhm" data-epoch="1642764252">-</span><script>document.getElementById('datetime-30ae3c1479e').innerHTML = ldst_strftime_dynamic_ymdhm(1642764252);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Bridget Cowgirl</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Bahamut&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Bridget Cowgirl (<i class="xiv-lds xiv-lds-home-world"></i>Bahamut) posted a new blog entry, "時期外れの守護天節が来た！."</p></div></div></div></a><a href="/lodestone/character/4060849/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/bae399e646df13b3457a4d1a4b5c3ad9_86da943caa70c8694707ab2ff74e68c9fc0_96x96.jpg?1642762434" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/community_finder/4ac14490ddb5f4ae48c1e8caadb4c7dc46a87e2c/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-b93415cb6ca" class="datetime_dynamic_ymdhm" data-epoch="1642764216">-</span><script>document.getElementById('datetime-b93415cb6ca').innerHTML = ldst_strftime_dynamic_ymdhm(1642764216);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Rutile Lupinus</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Fenrir&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__community_finder js__tooltip"data-tooltip="Community Finder"></span></div><div class="entry__activity__txt--message"><p>Rutile Lupinus (<i class="xiv-lds xiv-lds-home-world"></i>Fenrir) has started recruitment for the free company "Natto-Gohan (Fenrir)."</p></div></div></div></a><a href="/lodestone/character/30453207/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/761e5ae5634f51f240413bd90e44119d_d384cf5ad7db803f29799f36ebbc3eadfc0_96x96.jpg?1642762921" width="40" height="40" alt=""></div></a></div>
+
+
+					<div data-min_id="4838291234" class="entry more_"data-has_next=""><a href="/lodestone/community_finder/3aa64d7d2cfe314a0aa2ea263ce760b0428283c0/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-c963e405113" class="datetime_dynamic_ymdhm" data-epoch="1642764156">-</span><script>document.getElementById('datetime-c963e405113').innerHTML = ldst_strftime_dynamic_ymdhm(1642764156);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Ai Dairokutenmao</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Tiamat&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__community_finder js__tooltip"data-tooltip="Community Finder"></span></div><div class="entry__activity__txt--message"><p>Ai Dairokutenmao (<i class="xiv-lds xiv-lds-home-world"></i>Tiamat) has started recruitment for the free company "BlueMoon Revolutions (Tiamat)."</p></div></div></div></a><a href="/lodestone/character/3276729/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/ba913fdf2b75379a40c2e05dced7ac83_9f10d335198e90990f3437c5733468e7fc0_96x96.jpg?1642762900" width="40" height="40" alt=""></div></a></div>
+
+
+
+
+				</ul>
+
+
+			</div>
+
+
+
+			<div class="ldst__side__box">
+
+
+
+
+				<div class="heading--side">
+					<h3>Standings</h3>
+					<a href="/lodestone/ranking/" class="heading--side__icon icon-list__side js__tooltip" data-tooltip="See More"></a>
+				</div>
+
+
+				<h4 class="heading--side--sm">The Feast Rankings</h4>
+
+				<a href="/lodestone/ranking/thefeast/result/" class="entry__ranking__thefeast">
+					Pre-season is under way!<br>
+					View results of the previous season
+				</a>
+
+
+
+
+				<h4 class="heading--side--sm">Grand Company Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Luke Breitner</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Fenrir&nbsp;(Gaia)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/9658201/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/bb7875f35a390ed9493dfde91c4d0039_d384cf5ad7db803f29799f36ebbc3eadfc0_96x96.jpg?1642762694" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Kiryuin Satsuki</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/7250925/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/ba64ef52323ad0c23edaa3bafc9f4e82_58a84e851e55175d22158ca97af58a1ffc0_96x96.jpg?1642764909" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Ari Nuovo</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Phoenix&nbsp;(Light)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/19970354/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/1eb1b6c06bbadecb3c0f3b8cbb1b07e0_5047bc596a4bab2dc7f7c120bb22dec5fc0_96x96.jpg?1642762546" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+				</ul>
+
+
+
+				<h4 class="heading--side--sm">Free Company Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">brotherhood</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Moogle&nbsp;(Chaos)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9233364398528115650/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/F00_f4d64b4d75ce7d3be3ba37e24ccc7830_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S01_49d2902352dde56ae3c6423a937ac151_00_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">The Syndicate</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9231394073691073564/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/B08_de875598ba3f5ef9fe02858d29c85455_33_40x40.png" width="40" height="40">
+
+							<img src="https://img2.finalfantasyxiv.com/c/F1e_ed8a164ee0086dc3e36d078e76126110_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S5c_c48179b4e96cff6ed7c51da16ca90c11_04_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">CatOfHeart</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Masamune&nbsp;(Mana)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9236882835737003825/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/B0f_8c3fc97865a1c6bfa360c1bce22b9fa0_c0_40x40.png" width="40" height="40">
+
+							<img src="https://img2.finalfantasyxiv.com/c/F04_1223707ec2cfc1bde4ba8f0f85a74b24_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S33_f0483d3975a483769f674866ff99675e_01_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+				</ul>
+
+
+
+				<h4 class="heading--side--sm">Frontline Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Pharis Bloodborne</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ragnarok&nbsp;(Chaos)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/7338237/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/553c62b150030202afb4206e6f758b91_40d57ba713628f3f1ef5ef204b6d76d2fc0_96x96.jpg?1642764063" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Ni Xi</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Malboro&nbsp;(Crystal)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/34789289/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/356072546b70540163fcdc5bf3f1a6f3_2e97c13fdd593d15d543093f8a37b6f0fc0_96x96.jpg?1642762869" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Blueberry Lollipop</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/39019280/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/2be5c15e35dbd1670f814874fff1234b_58a84e851e55175d22158ca97af58a1ffc0_96x96.jpg?1642764072" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Jo Se</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Sargatanas&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/36466361/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/c9e98a67d1423c12fa7b4c38a41e80e0_ba22853447012a24cee115315d6a5bebfc0_96x96.jpg?1642763672" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Kayeson Mon&#39;roux</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Leviathan&nbsp;(Primal)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/36261740/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/f44e37565c9e753a163ffc1a0d5105ea_a91aae52cff9ef65932db06b150ffd47fc0_96x96.jpg?1642762411" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+				</ul>
+
+
+			</div>
+
+
+
+
+
+
+
+
+
+
+		</div>
+
+	</div>
+
+</div>
+
+
+
+<div id="link_spsite" class="link_sp-site"><a href="javascript:void(0)">Mobile Version</a><br></div><footer class="l__footer l__footer__eu"><div class="page-top"><span class="page-top__btn"></span></div><div class="l__footer__inner"><div class="l__footer__logo"><img src="https://img.finalfantasyxiv.com/lds/h/L/EbtcXqPUGzsVYdi23FpUR25oH4.png" width="320" height="32" alt=""></div><p class="l__footer__officiel">Official Information</p><ul class="l__footer__sns"><li><a href="https://www.facebook.com/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-facebook xiv-lds-3x"></i><span>Facebook</span></a></li><li class="l__footer__sns--twitter"><a href="https://twitter.com/ff_xiv_en" target="_blank"><i class="xiv-lds xiv-lds-twitter xiv-lds-3x"></i>Twitter</a> / <a href="https://twitter.com/FFXIV_NEWS_EN" target="_blank">Twitter News</a></li><li><a href="http://www.youtube.com/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-youtube xiv-lds-3x"></i><span>Official Channel</span></a></li><li><a href="https://www.instagram.com/ffxiv/" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-instagram xiv-lds-3x"></i><span>Instagram</span></a></li><li><a href="https://www.twitch.tv/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-twitch xiv-lds-3x"></i><span>Twitch</span></a></li></ul><ul class="l__footer__link-list"><li class="link_license" id="link_license"><a href="/license/" target="_blank">License</a></li><li><a href="https://support.eu.square-enix.com/rule.php?id=5383&la=2" target="_blank">Rules & Policies</a></li><li><a href="https://square-enix-games.com/en_GB/documents/privacy" target="_blank">Privacy Policy</a></li><li><a href="https://square-enix-games.com/en_GB/documents/cookies" target="_blank">Cookie Policy</a></li></ul></div><div class="l__footer__legal-area"><div class="l__footer__legal-area__inner clearfix"><div class="l__footer__legal-area__box"><ul class="l__footer__legal-area__bnr-list"><li><a href="http://www.pegi.info" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/h/8/bLhWLeqRDavUCuBhK8X0yB9bKA.png" width="41" height="50" alt="PEGI"></a></li><li><img src="https://img.finalfantasyxiv.com/lds/h/D/egrXwtjrQC8nFGhA1rWb0PO8R0.png" width="245" height="39" alt="PlayStation PS5 PS4"></li><li><img src="https://img.finalfantasyxiv.com/lds/h/E/38lyWv84H59UEwldgCOGU2B9dM.png" width="33" height="39" alt="PC"></li><li><img src="https://img.finalfantasyxiv.com/lds/h/v/hyXqlwktN4v0EssRTzkbMf_7OQ.png" width="30" height="39" alt="Mac"></li><li class="last"><img src="https://img.finalfantasyxiv.com/lds/h/U/15QxPO___EcPlhMI9ydNRRxEY8.png" width="90" height="39" alt="STEAM"></li></ul><p class="l__footer__legal-area__text">“<i class="ps"></i>”, “PlayStation”, “<i class="ps5"></i>” and “<i class="ps4"></i>” are registered trademarks or trademarks of Sony Interactive Entertainment Inc.<br />Mac is a trademark of Apple Inc.<br />©2021 Valve Corporation. Steam and the Steam logo are trademarks and/or registered trademarks of Valve Corporation in the U.S. and/or other countries.</p></div><div class="l__footer__legal-area__box"><p class="l__footer__legal-area__copyright">© 2010 - 2022 <a href="https://square-enix-games.com/en_GB" target="_blank">SQUARE ENIX</a> CO., LTD. All Rights Reserved.<br>ENDWALKER, SHADOWBRINGERS, STORMBLOOD, HEAVENSWARD and A REALM REBORN are registered trademarks or trademarks of Square Enix Co., Ltd.<br />FINAL FANTASY, FINAL FANTASY XIV, FFXIV, SQUARE ENIX and the SQUARE ENIX logo are registered trademarks or trademarks of Square Enix Holdings Co., Ltd.<br>LOGO ILLUSTRATION: © 2010, 2014, 2016, 2018, 2021 YOSHITAKA AMANO</p></div></div></div></footer>
+
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-43364669-4"></script>
+<script>
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+
+	(function() {
+		var gtag_config = {
+			'link_attribution': true,
+			'custom_map': {
+				'dimension1': 'login',
+				'dimension2': 'theme',
+				'dimension3': 'mychara',
+				'dimension4': 'character_link'
+			},
+			'login': 'notloginuser',
+			'theme':  'white',
+		};
+
+
+		gtag('js', new Date());
+
+		gtag('config', 'UA-43364669-4', gtag_config);
+		gtag('config', 'UA-43364669-1', gtag_config);
+	})();
+</script>
+
+
+
+
+<script src="https://img.finalfantasyxiv.com/lds/pc/en-gb/js/i18n.js?1642399092"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/i/2ur_0e4qXk_NwNv0bGjrUHThCM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/g/uQNBgvCaabd4gw5kMpaT-psp1Q.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/b/RKD_bGx738E81TyiPQN4kGf-_Y.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/Z/wqo4GxX1wALdnxx6xOv38NxFVY.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/e/TSPHxkEhdcyaPMm0rpoBtk1dZA.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/P/O9-IKBqOphhkhVvm2QPrR9x5p4.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/u/AVbQMBsmCh3GU9JNbEtRUHDioc.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/8/b_tPmOnEw1tyr2dp2InkGxUlMA.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/Y/6WaukM6m3WFE2JXrCEb6tsknik.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/E/ImNUSWkI-O9dQP5ADa41RiGxGY.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/t/kQLYFR8rOESAOiyT9o2PsRnLq0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/C/q1cplyit_St5sY1BUgBKFuLapM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/s/Gt4XmT3a3nu52yKZPoVWcvrfFM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/A/LATlIIBarKmGFTTVid87k_GPFg.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/W/r-0ziwRwdsVj1lEyFHfmVyFgKw.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/piXyeCeUEtNAzCIq6jXoqNimzE.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/t/85HyWVlETnECMXo9l40HahjdO0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/OIfkF0BnyASNQ0RswButWbIKCU.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/U/jhEwPt7MvJy47-ExjjZ3lHW3qI.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/0/f52zA7ACWvjEMB1oWe8kfyGWH0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/l/-_ePiHXNE_1t8LnRcmRAbhRME8.js"></script>
+<script src="https://www.youtube.com/iframe_api"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/P/MYGDtxveSuUwuhprm8oj1Hhuq8.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/it7tc9wvjlJJstEQUNjiModhdM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/n/HMQm8_JEoqrSmuv5RmmKgTldGc.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/B/ElvNJhxzt4ULBYHMPrt3JiAKGU.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/d/UfPsCOe_Nl7ytqem4KWdsftkY0.js"></script>
+
+
+<div id="dialog_bg" style="opacity:0; visibility: hidden;"></div>
+<!-- dialog -->
+<div name="ldstDialog" class="overlay__area js__overlay" style="opacity:0; visibility: hidden; top: 0px">
+	<p class="overlay__text--icon"></p>
+
+	<div class="outbound_consent hide">
+		<input type="checkbox" name="outbound_consent" value="1" id="outbound_consent" class="form__checkbox">
+		<label for="outbound_consent" class="form__checkbox__label form__outbound">
+			Do not show this message again.
+		</label>
+	</div>
+
+	<!-- SIMPLE DIALOG -->
+	<a href="javascript:void(0);" class="js__dialog_btn btn__color--radius js__overlay_ok">Confirm</a>
+	<!-- //SIMPLE DIALOG -->
+	<!-- CONFIRM DIALOG -->
+	<ul class="js__dialog_btn overlay__btn js__overlay_btn">
+		<li><a href="javascript:void(0);" class="js__overlay_yes">Yes</a></li>
+		<li><a href="javascript:void(0);" class="js__overlay_no">No</a></li>
+	</ul>
+	<!-- //CONFIRM DIALOG -->
+</div>
+<!-- //dialog -->
+
+
+
+
+</body>
+</html>

--- a/src/test/resources/data/lodestone/Character-33000061-Class-Jobs.html
+++ b/src/test/resources/data/lodestone/Character-33000061-Class-Jobs.html
@@ -1,0 +1,1817 @@
+<!DOCTYPE html>
+<html lang="en-gb" class="en-gb" xmlns:og="http://ogp.me/ns#" xmlns:fb="http://www.facebook.com/2008/fbml">
+<head><meta charset="utf-8">
+
+	<!-- Google Tag Manager -->
+	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	})(window,document,'script','digitalData','GTM-P37XSWJ');</script>
+	<!-- End Google Tag Manager -->
+
+	<title>Ivis Castalia | FINAL FANTASY XIV, The Lodestone</title>
+	<meta name="description" content="Character profile for Ivis Castalia.">
+	<meta name="keywords" content="FF14,FFXIV,Final Fantasy XIV,Final Fantasy 14,Lodestone,players' site,community site,A Realm Reborn,Heavensward,Stormblood,Shadowbringers,Endwalker,MMO">
+	<meta name="author" content="SQUARE ENIX Ltd.">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="format-detection" content="telephone=no">
+
+	<link rel="shortcut icon" type="image/vnd.microsoft.icon" href="https://img.finalfantasyxiv.com/lds/pc/global/images/favicon.ico?1490749553">
+	<link rel="apple-touch-icon-precomposed" href="https://img.finalfantasyxiv.com/lds/h/0/U2uGfVX4GdZgU1jASO0m9h_xLg.png">
+	<meta name="msapplication-TileImage" content="https://img.finalfantasyxiv.com/lds/h/0/U2uGfVX4GdZgU1jASO0m9h_xLg.png">
+
+	<meta name="msapplication-TileColor" content="#000000">
+	<link rel="alternate" hreflang="ja" href="https://jp.finalfantasyxiv.com/lodestone/character/33000061/class_job/">
+	<link rel="alternate" hreflang="en-us" href="https://na.finalfantasyxiv.com/lodestone/character/33000061/class_job/">
+	<link rel="alternate" hreflang="fr" href="https://fr.finalfantasyxiv.com/lodestone/character/33000061/class_job/">
+	<link rel="alternate" hreflang="de" href="https://de.finalfantasyxiv.com/lodestone/character/33000061/class_job/">
+
+
+	<meta name="google-site-verification" content="WwpBRGfcVWgP_LxTs8PHc6EcDM8eCt8Zqck1MAnVmZM">
+
+
+
+
+	<!--[if lt IE 9]>
+	<script src="https://img.finalfantasyxiv.com/lds/h/I/SMlNRnAvuilc1lYKBpzKWpmADs.js"></script>
+
+	<![endif]-->
+	<!-- ** CSS ** -->
+	<link href="https://img.finalfantasyxiv.com/lds/h/M/0kxkkawCCBg1ArBrU_c1cydINM.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/-/tUrZCLFtMgzaHil2OXxbmdw2a0.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/l/6D7j33OWZQd8eVk8IKWT15deH8.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/j/JgAulXN0McN_xRNcKLLbnNh4fs.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/F/wZHqGlYFe-0or10VJJtARsKyko.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/a/bmAvctt6TxsMwvFeI4NiKcWnZM.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/Q/mAASajjDE39sDOGkuOPDZPBt0s.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/w/YgRYdK0dq3N9UCU6nR-7J5PftA.css" rel="stylesheet">
+
+	<link href="https://img.finalfantasyxiv.com/lds/h/b/tInX1HM2lXTimf4ts8i-7wWr1Y.css" rel="stylesheet">
+
+	<link href="https://img.finalfantasyxiv.com/lds/h/w/cuKVxIZUo5Tf3xQ8a9_mn8jZDU.css" rel="stylesheet"
+		  class="sys_theme_css"
+
+		  data-theme_white="https://img.finalfantasyxiv.com/lds/h/w/cuKVxIZUo5Tf3xQ8a9_mn8jZDU.css"
+
+		  data-theme_black="https://img.finalfantasyxiv.com/lds/h/o/q3zLnccpt9t--buuJJqeuTpzOY.css"
+
+	>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<!-- ogp -->
+	<meta property="fb:app_id" content="1400886233468625">
+	<meta property="og:type" content="website">
+	<meta property="og:description" content="Character profile for Ivis Castalia.">
+	<meta property="og:title" content="Ivis Castalia | FINAL FANTASY XIV, The Lodestone">
+	<meta property="og:url" content="https://eu.finalfantasyxiv.com/lodestone/character/33000061/class_job/">
+	<meta property="og:site_name" content="FINAL FANTASY XIV, The Lodestone">
+	<meta property="og:locale" content="en_GB">
+
+	<meta property="og:image" content="https://img.finalfantasyxiv.com/lds/h/I/cy_FoBlOdFg3kBAQdaAxT19pTw.png">
+
+
+
+	<meta property="fb:pages" content="116214575870">
+
+
+	<meta name="twitter:card" content="summary_large_image">
+
+	<meta name="twitter:site" content="@ff_xiv_en">
+
+
+
+
+	<script>
+		var base_domain = 'finalfantasyxiv.com';
+		var ldst_subdomain = 'eu';
+		var strftime_fmt = {
+			'dateHHMM_now': 'Today %H:%M',
+			'dateYMDHMS': '%d/%m/%Y %H:%M:%S',
+			'dateYMDHM': '%d/%m/%Y %H:%M',
+			'dateYMDHM_jp': '%Y/%m/%d %H:%M',
+			'dateHM': '%H:%M',
+			'dateYMDH': '%d/%m/%Y %H',
+			'dateYMD': '%d/%m/%Y',
+			'dateEternal': '%d.%m.%Y',
+			'dateYMDW': '%d/%m/%Y (%a)',
+			'dateHM': '%H:%M',
+			'week.0': 'Sun.',
+			'week.1': 'Mon.',
+			'week.2': 'Tue.',
+			'week.3': 'Wed.',
+			'week.4': 'Thu.',
+			'week.5': 'Fri.',
+			'week.6': 'Sat.'
+		};
+		var base_uri   = '/lodestone/';
+		var api_uri    = '/lodestone/api/';
+		var static_uri = 'https://img.finalfantasyxiv.com/lds/';
+		var subdomain  = 'eu';
+		var csrf_token = 'b726b2475aab6e2b29c16ddcf48f50e5e7d76211';
+		var cis_origin = 'https://secure.square\u002denix.com';
+		var ldst_max_image_size = 31457280;
+		var eorzeadb = {
+			cdn_prefix: 'https://img.finalfantasyxiv.com/lds/',
+			version: '1641278251',
+			version_js_uri:  'https://img.finalfantasyxiv.com/lds/pc/global/js/eorzeadb/version.js',
+			dynamic_tooltip: false
+		};
+		var cookie_suffix = '';
+		var ldst_is_loggedin = false;
+		var show_achievement = false;
+	</script>
+	<script src="https://img.finalfantasyxiv.com/lds/h/A/PknAmzDJUZCNhTGtSGGMIGi5k4.js"></script>
+	<script src="https://img.finalfantasyxiv.com/lds/h/H/hBuD3_ZXTqwHX64YYCchtvgGSs.js"></script>
+
+
+
+
+
+
+
+
+
+</head>
+<body id="community" class=" lang_eu">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P37XSWJ"
+				  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+
+
+
+<div class="brand"><div class="brand__section">
+	<div class="brand__logo">
+		<a href="
+				https://square-enix-games.com/en_GB
+			" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/h/L/cxcD5kjeM52JRVwrrzIF4dZNe0.png" width="130" height="14" alt="SQUARE ENIX">
+		</a>
+	</div>
+
+
+	<div class="brand__search">
+		<form action="/lodestone/community/search/" class="brand__search__form">
+			<div class="brand__search__focus_bg"></div>
+			<div class="brand__search__base_bg"></div>
+			<input type="text" id="txt_search" class="brand__search--text" name="q" placeholder="Search">
+			<input type="submit" id="bt_search" class="brand__search--btn" value="">
+		</form>
+	</div>
+
+
+
+	<div class="brand__theme sys_theme_switcher">
+		<a href="javascript:void(0);"><i class="brand__theme--white sys_theme active js__tooltip" data-tooltip="Theme (Black)" data-theme="white"></i></a>
+		<a href="javascript:void(0);"><i class="brand__theme--black sys_theme js__tooltip" data-tooltip="Theme (White)" data-theme="black"></i></a>
+	</div>
+
+
+	<div class="brand__lang dropdown_trigger_box">
+		<a href="javascript:void(0);" class="brand__lang__btn brand__lang__en-gb dropdown_trigger">English</a>
+		<ul class="brand__lang__select dropdown">
+
+			<li><a href="https://jp.finalfantasyxiv.com/lodestone/character/33000061/class_job/" class="brand__lang__jp">日本語</a></li>
+
+			<li><a href="https://na.finalfantasyxiv.com/lodestone/character/33000061/class_job/" class="brand__lang__na">English</a></li>
+
+			<li><a href="https://eu.finalfantasyxiv.com/lodestone/character/33000061/class_job/" class="brand__lang__eu">English</a></li>
+
+			<li><a href="https://fr.finalfantasyxiv.com/lodestone/character/33000061/class_job/" class="brand__lang__fr">Français</a></li>
+
+			<li><a href="https://de.finalfantasyxiv.com/lodestone/character/33000061/class_job/" class="brand__lang__de">Deutsch</a></li>
+
+		</ul>
+	</div>
+
+
+
+	<div class="l__cross_menu eu">
+		<a href="javascript:void(null)" class="ffxiv_pr_cross_menu_button_eu"></a>
+		<script>
+			var ffxiv_pr_cross_menu = {
+				uri_js: '/cross_menu/uri.js'
+			};
+		</script>
+		<script src="https://img.finalfantasyxiv.com/lds/promo/pc/global/menu/loader.js"></script>
+	</div>
+
+</div></div>
+
+
+
+
+<header class="l__header">
+	<div class="l__header__inner l__header__bg_image" style="background-image: url(https://img.finalfantasyxiv.com/lds/banner/1074/headerImage_6_0_eu.jpg);">
+		<a href="/lodestone/" class="l__header__link_top"></a>
+
+
+		<a href="/lodestone/topics/detail/66a742165e9415790247c1a1f7d909abf5becb5c/?utm_source=lodestone&amp;utm_medium=pc_header&amp;utm_campaign=eu_6_0patch" class="l__header__link_management"></a>
+
+
+		<div class="l__header__login clearfix"><a href="/lodestone/account/login/" class="l__header__login__btn">
+			<img src="https://img.finalfantasyxiv.com/lds/h/z/6PLTZ82M99GJ7tKOee1RSwvNrQ.png" width="40" height="40" alt="" class="l__header__login__chara_silhouette">
+			<div class="l__header__login__txt">
+				<p>View Your Character Profile</p>
+				<div>Log In</div>
+			</div>
+		</a></div>
+
+
+	</div>
+</header>
+
+
+
+
+
+
+
+
+
+
+<div class="global-nav">
+	<nav class="main-nav eu">
+		<ul class="main-nav__area main-nav__area__community clearfix ">
+			<li class="main-nav__news main-nav__item">
+				<a href="/lodestone/news/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_news-top');"><span>News</span></a>
+				<nav class="sub-nav">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__news">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__news__icon">
+									<li>
+										<a href="/lodestone/news/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_top');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/8/2GwuzUcvqLa-hgQeLUyd8xarI8.png" width="32" height="32" alt="News">
+											News
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/topics/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_topics');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/5/67ZyAIzQUaYoWBmyvFwNvGmCnQ.png" width="32" height="32" alt="Topics">
+											Topics
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/1" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_notices');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/-/Y5JdwnEWYfyO7OlH27eKIm91Ok.png" width="32" height="32" alt="Notices">
+											Notices
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/2" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_maintenance');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/s/-JfULvMAf26L7AaU1OGaGYwanI.png" width="32" height="32" alt="Maintenance">
+											Maintenance
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/3" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_updates');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/p/HPudyOQcwdv97RBwj3FQC552ps.png" width="32" height="32" alt="Updates">
+											Updates
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/4" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_Status');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/S/-IC2xIQhTl2ymYW7deE1fOII04.png" width="32" height="32" alt="Status">
+											Status
+										</div></a>
+									</li>
+								</ul>
+								<ul class="sub-nav__news__text">
+									<li><a href="/lodestone/special/patchnote_log/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_patch-notes_special-sites');"><div>
+										Patch Notes and Special Sites
+										<span class="update">
+											Updated <span id="datetime-809be58ea09">-</span><script>document.getElementById('datetime-809be58ea09').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</div></a></li>
+									<li><a href="/lodestone/special/update_log/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_lodestone-update-notes');"><div>
+										<span class="sub_text">Official Community Site</span>
+										The Lodestone Update Notes
+										<span class="update">
+											Updated <span id="datetime-9e3752ac0c1">-</span><script>document.getElementById('datetime-9e3752ac0c1').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</div></a></li>
+									<li><a href="/lodestone/worldstatus/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_server-status');"><div>
+										Server Status
+									</div></a></li>
+								</ul>
+							</div>
+						</div>
+
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__promotion main-nav__item">
+				<a href="/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_begin-ff14-top');"><span>Getting Started</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__promotion">
+							<div class="sub-nav__list__inner">
+								<div class="sub-nav__promotion__inner">
+									<div class="sub-nav__promotion__link">
+										<div class="sub-nav__promotion__top">
+											<a href="/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_pr');"><img src="https://img.finalfantasyxiv.com/lds/h/P/ciPXy1S4-ssQuLQJvEF4JWVm5Q.jpg" width="632" height="140" alt="FINAL FANTASY XIV: A Realm Reborn"></a>
+										</div>
+										<ul class="sub-nav__promotion__page">
+											<li><a href="/benchmark/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_benchmark');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/S/2_8ofX4E90a7pS-p0mjFK_tc_U.png" width="64" height="40" alt="Benchmark">
+												<span>Benchmark</span>
+											</a></li>
+											<li><a href="
+
+													http://freetrial.finalfantasyxiv.com/
+												" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_freetrial');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/c/tWvZpXDc_g6yQd5YKK2k5jhuns.png" width="64" height="40" alt="Free Trial">
+												<span>Free Trial</span>
+											</a></li>
+											<li><a href="/product/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_product');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/m/NCNLGrn3U9M85ky-NscraujvN8.png" width="64" height="40" alt="Product">
+												<span>Product</span>
+											</a></li>
+											<li><a href="/winning/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_awards');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/j/udWU20sWmhYoEsQ_FtrAzVwJ3Q.png" width="64" height="40" alt="Awards and Nominations">
+												<span>Awards and Nominations</span>
+											</a></li>
+										</ul>
+									</div>
+									<div class="sub-nav__promotion__patch_site">
+										<a href="/endwalker/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_latest-expansion');"><span>
+											<img src="https://img.finalfantasyxiv.com/lds/h/f/sLzgsq-NNdSMdqLt6Mby4oROC0.png" width="296" height="232" alt="FINAL FANTASY XIV: Endwalker Special Site">
+										</span></a>
+									</div>
+								</div>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+			</li>
+			<li class="main-nav__playguide main-nav__item">
+				<a href="/lodestone/playguide/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_playguide-top');"><span>Play Guide</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__playguide">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__playguide__list">
+									<li><a href="/lodestone/playguide/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_playguide-top');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/P/Lfl3LVb9KMPa5Ye8yxftZkelbc.png" width="40" height="40" alt="Play Guide<br />Top">
+										<span>Play Guide<br />Top</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#game_playguide" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_game-playguide');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/q/qy4dUGMNkjoyVqPweYMIpOApik.png" width="40" height="40" alt="Gameplay Guide and<br />Beginners' Guide">
+										<span>Gameplay Guide and<br />Beginners' Guide</span>
+										<span class="update">
+											Updated <span id="datetime-1425682ca9d">-</span><script>document.getElementById('datetime-1425682ca9d').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/db/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_databese');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/N/OYPWhQVCkovUbVcMMck0O4HABU.png" width="40" height="40" alt="Eorzea Database">
+										<span>Eorzea Database</span>
+										<span class="update">
+											Updated <span id="datetime-84d9fe1e81a">-</span><script>document.getElementById('datetime-84d9fe1e81a').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#content_guide" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_contents-guide');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/W/wlHP1NMpdQHcPKUG-swlv71fhE.png" width="40" height="40" alt="Game Features">
+										<span>Game Features</span>
+										<span class="update">
+											Updated <span id="datetime-6ed93550318">-</span><script>document.getElementById('datetime-6ed93550318').innerHTML = ldst_strftime(1638518400, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#side_storyes" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_side-story');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/Z/1QWgBsVU7ZboWyMZlRjCQcDRJg.png" width="40" height="40" alt="Side Stories<br />and More">
+										<span>Side Stories<br />and More</span>
+										<span class="update">
+											Updated <span id="datetime-2eb59e8ec5c">-</span><script>document.getElementById('datetime-2eb59e8ec5c').innerHTML = ldst_strftime(1632470400, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#option_service" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_option-service');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/4fXwcEoJzDEmFRt-tD7PeeKvjE.png" width="40" height="40" alt="Additional Services">
+										<span>Additional Services</span>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__community main-nav__item">
+				<a href="/lodestone/community/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_community-top');"><span>Community</span></a>
+				<nav class="sub-nav">
+					<div class="sub-nav__area">
+
+
+						<div class="sub-nav__list sub-nav__community">
+							<div class="sub-nav__list__inner sub-nav__community__flex">
+								<div class="sub-nav__community__link">
+									<div class="sub-nav__community__top">
+										<div class="sub-nav__community__top__wrapper">
+											<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/q/GiEpnP3oCXluFjrlPlM-mgIbS8.png" width="16" height="16" alt="Community">Community</h2>
+											<ul class="sub-nav__community__list">
+												<li><a href="/lodestone/community/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_community-top');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/i/Sa5YF2-VFf4IJ1cjjFAbPf4GWg.png" width="40" height="40" alt="Community Wall">
+													<span>Community Wall</span>
+												</a></li>
+												<li><a href="/lodestone/blog/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_blog');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/h/6gPbLbzUQ_omC_mdXFUA3zPy7I.png" width="40" height="40" alt="Blog">
+													<span>Blog</span>
+												</a></li>
+											</ul>
+										</div>
+										<div class="sub-nav__community__top__wrapper">
+											<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/d/in_Sbc6SzxLU--Npa7URI-_kdg.png" width="16" height="16" alt="Member Recruitment">Member Recruitment</h2>
+											<ul class="sub-nav__community__list">
+												<li><a href="/lodestone/community_finder/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_community-finder');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/V/kHxwEjpY-Fme83ta8VIfi1kyLU.png" width="40" height="40" alt="Community Finder">
+													<span>Community Finder</span>
+												</a></li>
+												<li><a href="/lodestone/event/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_event-party');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/0/k5jD6-BJZHwKA2CtbNcDYZR6oY.png" width="40" height="40" alt="Event & Party Recruitment">
+													<span>Event & Party Recruitment</span>
+												</a></li>
+											</ul>
+										</div>
+									</div>
+									<div class="sub-nav__community__search">
+										<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/X/uQVT3DEl1xlFWHu3UZU4-RBtVk.png" width="16" height="16" alt="Search">Search</h2>
+										<ul class="sub-nav__community__list sub-nav__community__search__list">
+											<li><a href="/lodestone/character/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_chara-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/5/YcEF3K-5SgqU0BxZtT0D1Zsa2A.png" width="40" height="40" alt="Character Search">
+												<span>Character Search</span>
+											</a></li>
+											<li><a href="/lodestone/linkshell/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_ls-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/b/SPCgcBAk4HvMngGzk6H4MfSINg.png" width="40" height="40" alt="Linkshell Search">
+												<span>Linkshell Search</span>
+											</a></li>
+											<li><a href="/lodestone/crossworld_linkshell/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_cwls-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/L/NUGcPcy-C8jvx6oKgEXgwJ1ePE.png" width="40" height="40" alt="CWLS Search ">
+												<span>CWLS Search </span>
+											</a></li>
+											<li><a href="/lodestone/freecompany/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_fc-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/q/GJ-lsgAtsCCDwCm9te3a5sCjpU.png" width="40" height="40" alt="Free Company Search">
+												<span>Free Company Search</span>
+											</a></li>
+											<li><a href="/lodestone/pvpteam/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_pvp-team-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="PvP Team Search">
+												<span>PvP Team Search</span>
+											</a></li>
+										</ul>
+									</div>
+								</div>
+								<div class="sub-nav__community__side">
+									<div class="sub-nav__community__forum">
+										<ul class="sub-nav__community__forum__list">
+											<li><a href="https://forum.square-enix.com/ffxiv/forum.php" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum');">
+												<div class="forum">
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/r/maZ-sHaqn4PMFANUlbH4GzztFM.png" width="40" height="40" alt="Forums">
+													</i><span>Forums</span>
+												</div>
+											</a></li>
+											<li><a href="https://forum.square-enix.com/ffxiv/search.php?do=getdaily_ll&contenttype=vBForum_Post" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum-new-posts');">
+												<div>
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+													</i><span>New Posts</span>
+												</div>
+											</a></li>
+											<li><a href="
+
+														https://forum.square-enix.com/ffxiv/search.php?do=process&search_type=1&contenttypeid=1&devtrack=1&starteronly=0&showposts=1&childforums=1&forumchoice[]=619
+													" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum-dev-tracker');">
+												<div>
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+													</i><span>Dev Tracker</span>
+												</div>
+											</a></li>
+										</ul>
+									</div>
+									<ul class="sub-nav__community__fankit">
+										<li><a href="/lodestone/special/fankit/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_fankit');">
+											<div>
+												<span>Fan Kit</span>
+												<span class="update">
+													Updated <span id="datetime-4c1f2f4b20f">-</span><script>document.getElementById('datetime-4c1f2f4b20f').innerHTML = ldst_strftime(1640332800, 'YMD');</script>
+												</span>
+											</div>
+										</a></li>
+									</ul>
+								</div>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__ranking main-nav__item">
+				<a href="/lodestone/ranking/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_ranking-top');"><span>Standings</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__ranking">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__ranking__list">
+									<li><a href="/lodestone/ranking/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_ranking-top');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/E/NtymEFiUJfAh25ffTrADsVFkLQ.png" width="40" height="40" alt="Standings Top">
+										<span>Standings Top</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/thefeast/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_feast');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="The Feast Rankings">
+										<span>The Feast Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/deepdungeon2/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_deepdungeon2');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/_/qP22LgUoAFKDTRayb_TEYu6d7g.png" width="40" height="40" alt="Heaven-on-High Rankings">
+										<span>Heaven-on-High Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/deepdungeon/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_deepdungeon');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/p/op9iPrlMmYgTK3Q6NQKifyQOGA.png" width="40" height="40" alt="Palace of the Dead Rankings">
+										<span>Palace of the Dead Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/frontline/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_frontline');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="Frontline Standings">
+										<span>Frontline Standings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/gc/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_gc');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/o/uRmujlTx4X_5c6wETNxssK1d_4.png" width="40" height="40" alt="Grand Company Standings">
+										<span>Grand Company Standings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/fc/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_fc');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/q/GJ-lsgAtsCCDwCm9te3a5sCjpU.png" width="40" height="40" alt="Free Company Standings">
+										<span>Free Company Standings</span>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__help main-nav__item">
+				<a href="/lodestone/help/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_help-support-top');"><span>Help & Support</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__help">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__help__list">
+									<li><a href="/lodestone/help/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_help-support-top');">
+										<span>Help & Support</span>
+									</a></li>
+									<li><a href="/lodestone/help/about_the_lodestone/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_about-lodestone');">
+										<span>About the Lodestone</span>
+									</a></li>
+									<li><a href="
+
+											https://support.eu.square-enix.com/faq.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_faq');">
+										<span>FAQ</span>
+									</a></li>
+									<li><a href="
+
+											https://eu.square-enix.com/en/seaccount/
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_sqex-account');">
+										<span>Square Enix Account Information</span>
+									</a></li>
+								</ul>
+								<ul class="sub-nav__help__other">
+									<li><a href="
+
+											https://support.eu.square-enix.com/rule.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_rule-policies');">
+										<div>
+											<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+											</i><span>Rules & Policies</span>
+										</div>
+									</a></li>
+									<li><a href="
+
+											https://support.eu.square-enix.com/main.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_customer-service');">
+										<div>
+											<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+											</i><span>Customer Service</span>
+										</div>
+									</a></li>
+									<li><a href="https://sqex.to/Msp" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_mogstation');">
+										<div>
+											<i class="ic_mogst"><img src="https://img.finalfantasyxiv.com/lds/h/S/6IKp0hN6xQqTYPgnPIsd2fjzSI.png" width="32" height="32" alt="">
+											</i><span>Mog Station</span>
+										</div>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+		</ul>
+	</nav>
+</div>
+
+
+
+
+<div class="ldst__bg">
+
+	<div id="breadcrumb">
+		<ul itemscope itemscope itemtype="https://schema.org/BreadcrumbList" class="clearfix">
+			<li class="breadcrumb__home" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/" itemprop="item"><span itemprop="name">HOME</span></a>
+				<meta itemprop="position" content="1" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/community/" itemprop="item" class="breadcrumb__link"><span itemprop="name">Community</span></a>
+				<meta itemprop="position" content="2" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/character/" itemprop="item" class="breadcrumb__link"><span itemprop="name">Character</span></a>
+				<meta itemprop="position" content="3" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<span itemprop="name">Ivis Castalia</span>
+				<meta itemprop="position" content="4" />
+			</li>
+
+
+		</ul>
+	</div>
+
+
+	<h1 class="heading__title">Character</h1>
+
+
+
+	<nav class="btn__corner_block">
+		<ul class="btn__corner_block--3">
+
+			<li>
+				<a href="/lodestone/character/33000061/" class="btn__menu btn__menu--active">Profile</a>
+			</li>
+			<li>
+				<a href="/lodestone/character/33000061/blog/" class="btn__menu">Blog</a>
+			</li>
+			<li>
+				<a href="/lodestone/character/33000061/event/" class="btn__menu">Events</a>
+			</li>
+
+		</ul>
+	</nav>
+
+
+
+	<div class="ldst__contents clearfix">
+
+		<div class="ldst__main">
+
+
+
+			<div id="character" class="ldst__window">
+				<h2 class="heading--lg">Character</h2>
+
+
+
+				<div class="frame__chara js__toggle_wrapper">
+					<a href="/lodestone/character/33000061/" class="frame__chara__link">
+						<div class="frame__chara__face">
+							<img src="https://img2.finalfantasyxiv.com/f/c89729f713c11518b5f0b660bdd42b41_96ab1df8877c1f8ba6a89a39cccfd437fc0_96x96.jpg?1642765243" width="40" height="40" alt="">
+						</div>
+						<div class="frame__chara__box">
+
+							<p class="frame__chara__name">Ivis Castalia</p>
+
+							<p class="frame__chara__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Cactuar&nbsp;(Aether)</p>
+						</div>
+					</a>
+					<div class="parts__connect--state js__toggle_trigger">
+
+
+						<i class="parts__connect_off js__tooltip" data-tooltip="You have no connection with this character."></i>
+
+					</div>
+
+					<div class="parts__switch js__toggle_item">
+
+						<p class="character__connect__text">You have no connection with this character.</p>
+
+
+
+
+
+						<div class="heading--md-slide">Follower Requests</div>
+						<p class="entry__toggle__text">Before this character can be followed, you must first submit a follower request.<br />Do you wish to proceed?</p>
+						<ul class="btn__switch character__connect__form">
+							<li><a href="/lodestone/account/login/">Yes</a></li>
+							<li><a href="javascript:void(0)" class="js__toggle_trigger">No</a></li>
+						</ul>
+
+
+
+					</div>
+
+				</div>
+
+				<ul class="character__profile_tab js__character_menu clearfix"><li><a href="/lodestone/character/33000061/#profile">Profile</a></li><li class="character_menu__link"><a href="javascript:void(null)" class="selected">Class/Job</a></li><li class="disable"><span class="disable">Minions</span></li><li class="character_menu__link"><a href="/lodestone/character/33000061/mount/">Mounts</a></li><li class="character_menu__link"><a href="/lodestone/character/33000061/following/">Follow</a></li></ul>
+
+
+
+				<div class="character__content selected">
+
+
+
+
+					<h3 class="heading--md">DoW/DoM</h3>
+					<div class="clearfix">
+						<div class="character__job__role">
+							<h4 class="heading--lead"><img src="https://img.finalfantasyxiv.com/lds/h/Q/e8-CIpHMk6D5Dau_tyTx0Kt9js.png" width="24" height="24" class="character__job__icon__title">Tank</h4>
+							<ul class="character__job clearfix">
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/U/F5JzG9RPIKFSogtaKNBk455aYA.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Gladiator"
+
+									>Gladiator</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/N/St9rjDJB3xNKGYg-vwooZ4j6CM.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Marauder"
+
+									>Marauder</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/l/5CZEvDOMYMyVn2td9LZigsgw9s.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Dark Knight"
+
+									>Dark Knight</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/8/hg8ofSSOKzqng290No55trV4mI.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Gunbreaker"
+
+									>Gunbreaker</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+							</ul>
+						</div>
+						<div class="character__job__role">
+							<h4 class="heading--lead"><img src="https://img.finalfantasyxiv.com/lds/h/8/iUDBiCamMS05753pYarJPvRBkg.png" width="24" height="24" class="character__job__icon__title">Healer</h4>
+							<ul class="character__job clearfix">
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/s/gl62VOTBJrm7D_BmAZITngUEM8.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Conjurer"
+
+									>Conjurer</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/7/WdFey0jyHn9Nnt1Qnm-J3yTg5s.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Scholar"
+
+									>Scholar</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/1/erCgjnMSiab4LiHpWxVc-tXAqk.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Astrologian"
+
+									>Astrologian</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/g/_oYApASVVReLLmsokuCJGkEpk0.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Sage"
+
+									>Sage</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+							</ul>
+						</div>
+					</div>
+					<div class="clearfix">
+						<div class="character__job__role">
+							<h4 class="heading--lead"><img src="https://img.finalfantasyxiv.com/lds/h/V/d9PjsFG2F8p1wwBkwcpOzoETRQ.png" width="24" height="24" class="character__job__icon__title">Melee DPS</h4>
+							<ul class="character__job clearfix">
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/V/iW7IBKQ7oglB9jmbn6LwdZXkWw.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Pugilist"
+
+									>Pugilist</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/k/tYTpoSwFLuGYGDJMff8GEFuDQs.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Lancer"
+
+									>Lancer</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/y/wdwVVcptybfgSruoh8R344y_GA.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Rogue"
+
+									>Rogue</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/m/KndG72XtCFwaq1I1iqwcmO_0zc.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Samurai"
+
+									>Samurai</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/7/cLlXUaeMPJDM2nBhIeM-uDmPzM.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Reaper"
+
+									>Reaper</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+							</ul>
+						</div>
+						<div class="character__job__role">
+							<h4 class="heading--lead"><img src="https://img.finalfantasyxiv.com/lds/h/v/jkXOruroSp9ATWIA43ZiFGQB1Y.png" width="24" height="24" class="character__job__icon__title">Physical Ranged DPS</h4>
+							<ul class="character__job clearfix">
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/Q/ZpqEJWYHj9SvHGuV9cIyRNnIkk.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Archer"
+
+									>Archer</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/E/vmtbIlf6Uv8rVp2YFCWA25X0dc.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Machinist"
+
+									>Machinist</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/t/HK0jQ1y7YV9qm30cxGOVev6Cck.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Dancer"
+
+									>Dancer</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+							</ul>
+							<h4 class="heading--lead"><img src="https://img.finalfantasyxiv.com/lds/h/b/z3xeul_dFgcxt4E1MhigrzMDVE.png" width="24" height="24" class="character__job__icon__title">Magical Ranged DPS</h4>
+							<ul class="character__job clearfix">
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/4/IM3PoP6p06GqEyReygdhZNh7fU.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Thaumaturge"
+
+									>Thaumaturge</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/e/VYP1LKTDpt8uJVvUT7OKrXNL9E.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">15</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Arcanist"
+
+									>Arcanist</div>
+									<div class="character__job__exp">-- / 13,100</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/q/s3MlLUKmRAHy0pH57PnFStHmIw.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Red Mage"
+
+									>Red Mage</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/p/jdV3RRKtWzgo226CC09vjen5sk.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+										 data-tooltip="Blue Mage (Limited Job)"
+
+									>Blue Mage</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+							</ul>
+						</div>
+					</div>
+
+					<h3 class="heading--md">DoH/DoL</h3>
+					<div class="clearfix">
+						<div class="character__job__role">
+							<h4 class="heading--lead"><img src="https://img.finalfantasyxiv.com/lds/h/6/SX0lXLnrhyf1oQQ3aCra-PIjD8.png" width="24" height="24" class="character__job__icon__title">Disciples of the Hand</h4>
+							<ul class="character__job clearfix">
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/v/YCN6F-xiXf03Ts3pXoBihh2OBk.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Carpenter"
+
+									>Carpenter</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/5/EEHVV5cIPkOZ6v5ALaoN5XSVRU.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Blacksmith"
+
+									>Blacksmith</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/G/Rq5wcK3IPEaAB8N-T9l6tBPxCY.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Armorer"
+
+									>Armorer</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/L/LbEjgw0cwO_2gQSmhta9z03pjM.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Goldsmith"
+
+									>Goldsmith</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/b/ACAcQe3hWFxbWRVPqxKj_MzDiY.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Leatherworker"
+
+									>Leatherworker</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/X/E69jrsOMGFvFpCX87F5wqgT_Vo.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Weaver"
+
+									>Weaver</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/C/bBVQ9IFeXqjEdpuIxmKvSkqalE.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Alchemist"
+
+									>Alchemist</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/m/1kMI2v_KEVgo30RFvdFCyySkFo.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Culinarian"
+
+									>Culinarian</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+							</ul>
+						</div>
+						<div class="character__job__role">
+							<h4 class="heading--lead"><img src="https://img.finalfantasyxiv.com/lds/h/c/_pbf8dASjs-lT233ljqfamS52o.png" width="24" height="24" class="character__job__icon__title">Disciples of the Land</h4>
+							<ul class="character__job clearfix">
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/A/aM2Dd6Vo4HW_UGasK7tLuZ6fu4.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Miner"
+
+									>Miner</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/jGRnjIlwWridqM-mIPNew6bhHM.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Botanist"
+
+									>Botanist</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+
+
+
+								<li>
+									<i class="character__job__icon"><img src="https://img.finalfantasyxiv.com/lds/h/x/B4Azydbn7Prubxt7OL9p1LZXZ0.png" width="24" height="24" alt=""></i>
+									<div class="character__job__level">-</div>
+									<div class="character__job__name js__tooltip"
+
+
+										 data-tooltip="Fisher"
+
+									>Fisher</div>
+									<div class="character__job__exp">-- / -</div>
+								</li>
+
+							</ul>
+						</div>
+					</div>
+
+
+
+
+				</div>
+			</div>
+		</div>
+
+		<div class="ldst__side">
+
+
+
+
+			<div class="l__rside__bnr clearfix">
+				<a href="https://forum.square-enix.com/ffxiv/forum.php?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_forum" target="_blank" class="l__rside__bnr--forums"><img src="https://img.finalfantasyxiv.com/lds/h/i/i3r6u3moBzQFfijSTu9k3EJirQ.png" width="100" height="62" alt="Forums"></a><a href="https://sqex.to/Msp?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_mogstation" target="_blank" class="l__rside__bnr--mog_station"><img src="https://img.finalfantasyxiv.com/lds/h/3/GjsnqfVxPQrE4Jve8GvKZABF5w.png" width="100" height="62" alt="Mog Station"></a><a href="/pr/blog/?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_officalblog" target="_blank" class="l__rside__bnr--blog"><img src="https://img.finalfantasyxiv.com/lds/h/d/nVeXvIIStLv3npokivV0EzkKwI.png" width="100" height="62" alt="Official Blog"></a>
+			</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+			<div class="mb10"><a href="/endwalker/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_endwalker"><img src="https://img.finalfantasyxiv.com/lds/banner/998/v60_211207_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="https://store.finalfantasyxiv.com/ffxivstore/en-gb/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_onlinestore" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/banner/916/LDS_ffxivos_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/special/2022/All_Saints_Wake/rjk7wevhuy?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_all_saints_wake"><img src="https://img.finalfantasyxiv.com/lds/banner/1119/mnbn_all_saints_wake-1_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/community_finder/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_cf202112"><img src="https://img.finalfantasyxiv.com/lds/banner/1104/LDS_CF_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/jobguide/battle/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_jobguide"><img src="https://img.finalfantasyxiv.com/lds/banner/1089/jobguide_v60_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/uiguide/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_uiguide"><img src="https://img.finalfantasyxiv.com/lds/banner/671/pc_uiguide_eu.jpg"></a></div>
+
+
+
+			<div class="conducting_area">
+
+				<img src="https://img.finalfantasyxiv.com/lds/h/z/EhLfs3eya3Aidfr8A6PbXOBgtA.png" width="300" height="218" alt="">
+
+				<div class="inr">
+					<a href="
+				http://freetrial.finalfantasyxiv.com/" class="bt_conducting">
+						<img src="https://img.finalfantasyxiv.com/lds/h/s/3KRua4vzZJvRXn0IMk8Da103bw.png" width="284" height="80" alt="Start Your Free Trial">
+					</a>
+					<a href="/product/?utm_source=lodestone&utm_medium=pc_buyarea&utm_campaign=eu_buynow" class="bt_conducting" target="_blank">
+						<img src="https://img.finalfantasyxiv.com/lds/h/p/to8CzK_gktAHpLuSGzCkNdLfWo.png" width="284" height="80" alt="BUY NOW!">
+					</a>			<a href="https://support.eu.square-enix.com/faqarticle.php?id=5383&la=2&kid=78775" onmousedown="ga('send', 'event', 'lodestone_eu', 'howtoupgrade_link', 'EU-lodestone-UG_20170620', true);" class="bt_ft_migration">			<img src="https://img.finalfantasyxiv.com/lds/h/0/5rrJdYAcP3if6zX6d62dHV3t34.png" width="260" height="80" alt="Upgrade Your Free Trial<br />to the Full Version">
+				</a>
+				</div>
+			</div>
+
+
+
+
+
+
+
+
+
+			<div class="mb10"><a href="/tales_of_adventure/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_tales_of_adventure"><img src="https://img.finalfantasyxiv.com/lds/banner/1079/LDS_Tales_of_Adventure_v60_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/special/friend_recruit/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_friendrecruit"><img src="https://img.finalfantasyxiv.com/lds/banner/203/bn_Recruit_a_Friend_eu.png"></a></div>
+
+
+
+
+
+
+			<div class="ldst__side__box">
+
+
+
+				<div class="heading--side">
+					<h3>Community Wall</h3>
+					<a href="/lodestone/community/" class="heading--side__icon icon-list__side js__tooltip" data-tooltip="See More"></a>
+				</div>
+				<div class="heading__icon parts__space--reset js__toggle_wrapper">
+					<h4>Recent Activity</h4>
+					<i class="icon-btn__filter js__toggle_trigger js__tooltip" data-tooltip="Filter"></i>
+					<div class="parts__switch parts__switch--filter js__toggle_item">
+						<p class="parts__text">
+							Filter which items are to be displayed below.<br>
+							<span class="parts__text__notes">
+				* Notifications for standings updates are shared across all Worlds.<br>
+				* Notifications for PvP team formations are shared for all languages.<br>
+				* Notifications for free company formations are shared for all languages.
+			</span>
+						</p>
+
+
+						<div class="form__horizontal js__communitywall_filter">
+							<input type="hidden" name="order" value=""><h5 class="heading--side--lead">Sort by</h5><ul class="form__row parts__spce--8"><li><input type="checkbox" name="community_type" value="blog" class="form__checkbox" id="community_type01"><label class="form__checkbox__label" for="community_type01">Blog</label></li><li><input type="checkbox" name="community_type" value="event" class="form__checkbox" id="community_type02"><label class="form__checkbox__label" for="community_type02">Event & Party Recruitment</label></li><li><input type="checkbox" name="community_type" value="fc" class="form__checkbox" id="community_type03"><label class="form__checkbox__label" for="community_type03">Free Company</label></li><li><input type="checkbox" name="community_type" value="db" class="form__checkbox" id="community_type04"><label class="form__checkbox__label" for="community_type04">Eorzea Database</label></li><li><input type="checkbox" name="community_type" value="ranking" class="form__checkbox" id="community_type05"><label class="form__checkbox__label" for="community_type05">Standings</label></li><li><input type="checkbox" name="community_type" value="pvpteam" class="form__checkbox" id="community_type06"><label class="form__checkbox__label" for="community_type06">PvP Team</label></li><li><input type="checkbox" name="community_type" value="community_finder" class="form__checkbox" id="community_type07"><label class="form__checkbox__label" for="community_type07">Community Finder</label></li></ul><h5 class="heading--side--lead">Data Center / Home World</h5><div class="select-pulldown"><label class="control-label" for="world"></label><select name="community_worldname" class="select-pulldown__open"><option value="">Select All</option><optgroup label="Data Center"><option value="_dc_Elemental">Elemental</option><option value="_dc_Gaia">Gaia</option><option value="_dc_Mana">Mana</option><option value="_dc_Aether">Aether</option><option value="_dc_Primal">Primal</option><option value="_dc_Crystal">Crystal</option><option value="_dc_Chaos">Chaos</option><option value="_dc_Light">Light</option></optgroup><optgroup label="Home World"><option value="Adamantoise">Adamantoise</option><option value="Aegis">Aegis</option><option value="Alexander">Alexander</option><option value="Anima">Anima</option><option value="Asura">Asura</option><option value="Atomos">Atomos</option><option value="Bahamut">Bahamut</option><option value="Balmung">Balmung</option><option value="Behemoth">Behemoth</option><option value="Belias">Belias</option><option value="Brynhildr">Brynhildr</option><option value="Cactuar">Cactuar</option><option value="Carbuncle">Carbuncle</option><option value="Cerberus">Cerberus</option><option value="Chocobo">Chocobo</option><option value="Coeurl">Coeurl</option><option value="Diabolos">Diabolos</option><option value="Durandal">Durandal</option><option value="Excalibur">Excalibur</option><option value="Exodus">Exodus</option><option value="Faerie">Faerie</option><option value="Famfrit">Famfrit</option><option value="Fenrir">Fenrir</option><option value="Garuda">Garuda</option><option value="Gilgamesh">Gilgamesh</option><option value="Goblin">Goblin</option><option value="Gungnir">Gungnir</option><option value="Hades">Hades</option><option value="Hyperion">Hyperion</option><option value="Ifrit">Ifrit</option><option value="Ixion">Ixion</option><option value="Jenova">Jenova</option><option value="Kujata">Kujata</option><option value="Lamia">Lamia</option><option value="Leviathan">Leviathan</option><option value="Lich">Lich</option><option value="Louisoix">Louisoix</option><option value="Malboro">Malboro</option><option value="Mandragora">Mandragora</option><option value="Masamune">Masamune</option><option value="Mateus">Mateus</option><option value="Midgardsormr">Midgardsormr</option><option value="Moogle">Moogle</option><option value="Odin">Odin</option><option value="Omega">Omega</option><option value="Pandaemonium">Pandaemonium</option><option value="Phoenix">Phoenix</option><option value="Ragnarok">Ragnarok</option><option value="Ramuh">Ramuh</option><option value="Ridill">Ridill</option><option value="Sargatanas">Sargatanas</option><option value="Shinryu">Shinryu</option><option value="Shiva">Shiva</option><option value="Siren">Siren</option><option value="Spriggan">Spriggan</option><option value="Tiamat">Tiamat</option><option value="Titan">Titan</option><option value="Tonberry">Tonberry</option><option value="Twintania">Twintania</option><option value="Typhon">Typhon</option><option value="Ultima">Ultima</option><option value="Ultros">Ultros</option><option value="Unicorn">Unicorn</option><option value="Valefor">Valefor</option><option value="Yojimbo">Yojimbo</option><option value="Zalera">Zalera</option><option value="Zeromus">Zeromus</option><option value="Zodiark">Zodiark</option></optgroup></select></div><h5 class="heading--side--lead">Primary language</h5><div class="select-pulldown"><label class="control-label" for="lang"></label><select name="community_lang" class="select-pulldown__open"><option value="">Select All</option><option value="ja">Japanese</option><option value="en">English</option><option value="de">German</option><option value="fr">French</option></select></div><h5 class="heading--side--lead">Displaying</h5><div class="select-pulldown"><label class="control-label" for="limit"></label><select name="community_limit" class="select-pulldown__open"><option value="10">10</option><option value="20">20</option><option value="30">30</option></select></div><div class="form__submit form__submit--full"><input type="submit" value="Filter" class="js__bt_communitywall_filter"></div>
+						</div>
+
+
+					</div>
+				</div>
+
+
+				<ul class="side__list__box">
+
+
+					<div class="entry more_"><a href="/lodestone/character/8270042/blog/4942263/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-a56bb0bdcea" class="datetime_dynamic_ymdhm" data-epoch="1642766873">-</span><script>document.getElementById('datetime-a56bb0bdcea').innerHTML = ldst_strftime_dynamic_ymdhm(1642766873);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Kin Giga</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Typhon&nbsp;(Elemental)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Kin Giga (<i class="xiv-lds xiv-lds-home-world"></i>Typhon) posted a new blog entry, "乾杯するぞ〜♪."</p></div></div></div></a><a href="/lodestone/character/8270042/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/3158dad773acbe9d2219b27dd89c6765_32d8c9c7cd5f62d62da2d31b6750a680fc0_96x96.jpg?1642765400" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/32605712/blog/4942261/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-2536a33ab41" class="datetime_dynamic_ymdhm" data-epoch="1642766797">-</span><script>document.getElementById('datetime-2536a33ab41').innerHTML = ldst_strftime_dynamic_ymdhm(1642766797);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Joe Perrorist</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Yojimbo&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Joe Perrorist (<i class="xiv-lds xiv-lds-home-world"></i>Yojimbo) posted a new blog entry, "【Gaia】零式1-3消化4攻略固定募集【1セット週4活動】."</p></div></div></div></a><a href="/lodestone/character/32605712/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/ded39e003b8fb83c773e61265c1b6d3a_4a92c619bde4f34cfa77e05fef21ad85fc0_96x96.jpg?1642766324" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/freecompany/9230408911272672748/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header--common clearfix"><time class="entry__activity__time"><span id="datetime-6c26d8ef351" class="datetime_dynamic_ymdhm" data-epoch="1642766752">-</span><script>document.getElementById('datetime-6c26d8ef351').innerHTML = ldst_strftime_dynamic_ymdhm(1642766752);</script></time></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__fc js__tooltip"data-tooltip="Free Company"></span></div><div class="entry__activity__txt--message"><p>g&#39;suffa Prost! (Typhon) has been formed.</p></div></div></div></a><div class="entry__activity__link"><img src="https://img.finalfantasyxiv.com/lds/h/9/_Huf58epDlt9vXiO8IIfPXxtXI.png" width="50" height="50" alt=""></div></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/39792590/blog/4942260/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-7fb4619a8b5" class="datetime_dynamic_ymdhm" data-epoch="1642766751">-</span><script>document.getElementById('datetime-7fb4619a8b5').innerHTML = ldst_strftime_dynamic_ymdhm(1642766751);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Miel Citron</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ixion&nbsp;(Mana)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Miel Citron (<i class="xiv-lds xiv-lds-home-world"></i>Ixion) posted a new blog entry, "ソロナイトが行く　零式アレキ天動編４層."</p></div></div></div></a><a href="/lodestone/character/39792590/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/05c2d7738575249d9169c27166e1b256_7126768d768f6c6c7fed3eaee98c3a8afc0_96x96.jpg?1642764587" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/community_finder/0132e3d1d83bce4a1745b332714df4b80bd2928a/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-725f66df24f" class="datetime_dynamic_ymdhm" data-epoch="1642766665">-</span><script>document.getElementById('datetime-725f66df24f').innerHTML = ldst_strftime_dynamic_ymdhm(1642766665);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Mevius Axe</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Fenrir&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__community_finder js__tooltip"data-tooltip="Community Finder"></span></div><div class="entry__activity__txt--message"><p>Mevius Axe (<i class="xiv-lds xiv-lds-home-world"></i>Fenrir) has started recruitment for the free company "Leone (Fenrir)."</p></div></div></div></a><a href="/lodestone/character/23626831/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/7f75ced5d0c977d1d49c8e7c53e9f464_d384cf5ad7db803f29799f36ebbc3eadfc0_96x96.jpg?1642764296" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/playguide/db/item/759442f53f2/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-e7a97c6b83b" class="datetime_dynamic_ymdhm" data-epoch="1642766633">-</span><script>document.getElementById('datetime-e7a97c6b83b').innerHTML = ldst_strftime_dynamic_ymdhm(1642766633);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Kahlann Haven</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Louisoix&nbsp;(Chaos)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__db js__tooltip"data-tooltip="Eorzea Database"></span></div><div class="entry__activity__txt--message"><p>Kahlann Haven (<i class="xiv-lds xiv-lds-home-world"></i>Louisoix) commented on the Othardian Lumpsucker entry of the Eorzea Database.</p></div></div></div></a><a href="/lodestone/character/13489569/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/389c51de1d47ac4abb39bfd791bc05a9_0a122616f3718d3f45cab10fd8fc1604fc0_96x96.jpg?1642764279" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/3645585/blog/4942258/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-7cb9f32b6b4" class="datetime_dynamic_ymdhm" data-epoch="1642766569">-</span><script>document.getElementById('datetime-7cb9f32b6b4').innerHTML = ldst_strftime_dynamic_ymdhm(1642766569);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Zeronos Rider</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Belias&nbsp;(Mana)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Zeronos Rider (<i class="xiv-lds xiv-lds-home-world"></i>Belias) posted a new blog entry, "ManaDC】6.0零式固定欠員募集します【求BH！】."</p></div></div></div></a><a href="/lodestone/character/3645585/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/a1d627b8437319c8674e63cff02a4aa3_894c4bd0beab2e2beb44b74f4c4bd206fc0_96x96.jpg?1642764368" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/32371321/blog/4942256/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-0c3e4531765" class="datetime_dynamic_ymdhm" data-epoch="1642766152">-</span><script>document.getElementById('datetime-0c3e4531765').innerHTML = ldst_strftime_dynamic_ymdhm(1642766152);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Tomo Yuuzuki</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Hades&nbsp;(Mana)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Tomo Yuuzuki (<i class="xiv-lds xiv-lds-home-world"></i>Hades) posted a new blog entry, "守護天節ハウジング."</p></div></div></div></a><a href="/lodestone/character/32371321/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/6740cdefed5f239d8e7a1fccb277992f_a4730651230dd43cb129562a30d531aefc0_96x96.jpg?1642766827" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/community_finder/e8e54a741f7f25fd147e1cd02c213e105d9da420/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-d766d725d1f" class="datetime_dynamic_ymdhm" data-epoch="1642766142">-</span><script>document.getElementById('datetime-d766d725d1f').innerHTML = ldst_strftime_dynamic_ymdhm(1642766142);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Rayner Fayne</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Zodiark&nbsp;(Light)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__community_finder js__tooltip"data-tooltip="Community Finder"></span></div><div class="entry__activity__txt--message"><p>Rayner Fayne (<i class="xiv-lds xiv-lds-home-world"></i>Zodiark) has started recruitment for the free company "Dawn of Heroes (Zodiark)."</p></div></div></div></a><a href="/lodestone/character/7830431/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/8185413e5caa900e4d0eb0960fa29e09_c274370774c6bc3483cc8740805f41bcfc0_96x96.jpg?1642764973" width="40" height="40" alt=""></div></a></div>
+
+
+					<div data-min_id="4838351966" class="entry more_"data-has_next=""><a href="/lodestone/character/19240100/blog/4942194/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-a5a36ba0aa1" class="datetime_dynamic_ymdhm" data-epoch="1642766142">-</span><script>document.getElementById('datetime-a5a36ba0aa1').innerHTML = ldst_strftime_dynamic_ymdhm(1642766142);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Azami Momose</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Alexander&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Azami Momose (<i class="xiv-lds xiv-lds-home-world"></i>Alexander) posted a new blog entry, "零式や絶の固定メンバーを募集するときに考えていること【早期攻略固定の場合】."</p></div></div></div></a><a href="/lodestone/character/19240100/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/ef09ad1f1c1ca681da466c4b7a224a59_b7a71d8799cf6dd75b711a7f52de6675fc0_96x96.jpg?1642765596" width="40" height="40" alt=""></div></a></div>
+
+
+
+
+				</ul>
+
+
+			</div>
+
+
+
+			<div class="ldst__side__box">
+
+
+
+
+				<div class="heading--side">
+					<h3>Standings</h3>
+					<a href="/lodestone/ranking/" class="heading--side__icon icon-list__side js__tooltip" data-tooltip="See More"></a>
+				</div>
+
+
+				<h4 class="heading--side--sm">The Feast Rankings</h4>
+
+				<a href="/lodestone/ranking/thefeast/result/" class="entry__ranking__thefeast">
+					Pre-season is under way!<br>
+					View results of the previous season
+				</a>
+
+
+
+
+				<h4 class="heading--side--sm">Grand Company Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Luke Breitner</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Fenrir&nbsp;(Gaia)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/9658201/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/bb7875f35a390ed9493dfde91c4d0039_d384cf5ad7db803f29799f36ebbc3eadfc0_96x96.jpg?1642766294" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Kiryuin Satsuki</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/7250925/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/ba64ef52323ad0c23edaa3bafc9f4e82_58a84e851e55175d22158ca97af58a1ffc0_96x96.jpg?1642764909" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Ari Nuovo</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Phoenix&nbsp;(Light)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/19970354/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/1eb1b6c06bbadecb3c0f3b8cbb1b07e0_5047bc596a4bab2dc7f7c120bb22dec5fc0_96x96.jpg?1642766146" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+				</ul>
+
+
+
+				<h4 class="heading--side--sm">Free Company Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">brotherhood</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Moogle&nbsp;(Chaos)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9233364398528115650/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/F00_f4d64b4d75ce7d3be3ba37e24ccc7830_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S01_49d2902352dde56ae3c6423a937ac151_00_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">The Syndicate</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9231394073691073564/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/B08_de875598ba3f5ef9fe02858d29c85455_33_40x40.png" width="40" height="40">
+
+							<img src="https://img2.finalfantasyxiv.com/c/F1e_ed8a164ee0086dc3e36d078e76126110_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S5c_c48179b4e96cff6ed7c51da16ca90c11_04_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">CatOfHeart</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Masamune&nbsp;(Mana)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9236882835737003825/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/B0f_8c3fc97865a1c6bfa360c1bce22b9fa0_c0_40x40.png" width="40" height="40">
+
+							<img src="https://img2.finalfantasyxiv.com/c/F04_1223707ec2cfc1bde4ba8f0f85a74b24_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S33_f0483d3975a483769f674866ff99675e_01_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+				</ul>
+
+
+
+				<h4 class="heading--side--sm">Frontline Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Pharis Bloodborne</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ragnarok&nbsp;(Chaos)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/7338237/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/553c62b150030202afb4206e6f758b91_40d57ba713628f3f1ef5ef204b6d76d2fc0_96x96.jpg?1642764063" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Ni Xi</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Malboro&nbsp;(Crystal)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/34789289/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/356072546b70540163fcdc5bf3f1a6f3_2e97c13fdd593d15d543093f8a37b6f0fc0_96x96.jpg?1642766469" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Blueberry Lollipop</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/39019280/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/2be5c15e35dbd1670f814874fff1234b_58a84e851e55175d22158ca97af58a1ffc0_96x96.jpg?1642764072" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Jo Se</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Sargatanas&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/36466361/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/c9e98a67d1423c12fa7b4c38a41e80e0_ba22853447012a24cee115315d6a5bebfc0_96x96.jpg?1642763672" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Kayeson Mon&#39;roux</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Leviathan&nbsp;(Primal)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/36261740/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/f44e37565c9e753a163ffc1a0d5105ea_a91aae52cff9ef65932db06b150ffd47fc0_96x96.jpg?1642766011" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+				</ul>
+
+
+			</div>
+
+
+
+
+
+
+
+
+
+
+		</div>
+
+	</div>
+
+</div>
+
+
+
+<div id="link_spsite" class="link_sp-site"><a href="javascript:void(0)">Mobile Version</a><br></div><footer class="l__footer l__footer__eu"><div class="page-top"><span class="page-top__btn"></span></div><div class="l__footer__inner"><div class="l__footer__logo"><img src="https://img.finalfantasyxiv.com/lds/h/L/EbtcXqPUGzsVYdi23FpUR25oH4.png" width="320" height="32" alt=""></div><p class="l__footer__officiel">Official Information</p><ul class="l__footer__sns"><li><a href="https://www.facebook.com/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-facebook xiv-lds-3x"></i><span>Facebook</span></a></li><li class="l__footer__sns--twitter"><a href="https://twitter.com/ff_xiv_en" target="_blank"><i class="xiv-lds xiv-lds-twitter xiv-lds-3x"></i>Twitter</a> / <a href="https://twitter.com/FFXIV_NEWS_EN" target="_blank">Twitter News</a></li><li><a href="http://www.youtube.com/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-youtube xiv-lds-3x"></i><span>Official Channel</span></a></li><li><a href="https://www.instagram.com/ffxiv/" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-instagram xiv-lds-3x"></i><span>Instagram</span></a></li><li><a href="https://www.twitch.tv/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-twitch xiv-lds-3x"></i><span>Twitch</span></a></li></ul><ul class="l__footer__link-list"><li class="link_license" id="link_license"><a href="/license/" target="_blank">License</a></li><li><a href="https://support.eu.square-enix.com/rule.php?id=5383&la=2" target="_blank">Rules & Policies</a></li><li><a href="https://square-enix-games.com/en_GB/documents/privacy" target="_blank">Privacy Policy</a></li><li><a href="https://square-enix-games.com/en_GB/documents/cookies" target="_blank">Cookie Policy</a></li></ul></div><div class="l__footer__legal-area"><div class="l__footer__legal-area__inner clearfix"><div class="l__footer__legal-area__box"><ul class="l__footer__legal-area__bnr-list"><li><a href="http://www.pegi.info" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/h/8/bLhWLeqRDavUCuBhK8X0yB9bKA.png" width="41" height="50" alt="PEGI"></a></li><li><img src="https://img.finalfantasyxiv.com/lds/h/D/egrXwtjrQC8nFGhA1rWb0PO8R0.png" width="245" height="39" alt="PlayStation PS5 PS4"></li><li><img src="https://img.finalfantasyxiv.com/lds/h/E/38lyWv84H59UEwldgCOGU2B9dM.png" width="33" height="39" alt="PC"></li><li><img src="https://img.finalfantasyxiv.com/lds/h/v/hyXqlwktN4v0EssRTzkbMf_7OQ.png" width="30" height="39" alt="Mac"></li><li class="last"><img src="https://img.finalfantasyxiv.com/lds/h/U/15QxPO___EcPlhMI9ydNRRxEY8.png" width="90" height="39" alt="STEAM"></li></ul><p class="l__footer__legal-area__text">“<i class="ps"></i>”, “PlayStation”, “<i class="ps5"></i>” and “<i class="ps4"></i>” are registered trademarks or trademarks of Sony Interactive Entertainment Inc.<br />Mac is a trademark of Apple Inc.<br />©2021 Valve Corporation. Steam and the Steam logo are trademarks and/or registered trademarks of Valve Corporation in the U.S. and/or other countries.</p></div><div class="l__footer__legal-area__box"><p class="l__footer__legal-area__copyright">© 2010 - 2022 <a href="https://square-enix-games.com/en_GB" target="_blank">SQUARE ENIX</a> CO., LTD. All Rights Reserved.<br>ENDWALKER, SHADOWBRINGERS, STORMBLOOD, HEAVENSWARD and A REALM REBORN are registered trademarks or trademarks of Square Enix Co., Ltd.<br />FINAL FANTASY, FINAL FANTASY XIV, FFXIV, SQUARE ENIX and the SQUARE ENIX logo are registered trademarks or trademarks of Square Enix Holdings Co., Ltd.<br>LOGO ILLUSTRATION: © 2010, 2014, 2016, 2018, 2021 YOSHITAKA AMANO</p></div></div></div></footer>
+
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-43364669-4"></script>
+<script>
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+
+	(function() {
+		var gtag_config = {
+			'link_attribution': true,
+			'custom_map': {
+				'dimension1': 'login',
+				'dimension2': 'theme',
+				'dimension3': 'mychara',
+				'dimension4': 'character_link'
+			},
+			'login': 'notloginuser',
+			'theme':  'white',
+		};
+
+
+		gtag('js', new Date());
+
+		gtag('config', 'UA-43364669-4', gtag_config);
+		gtag('config', 'UA-43364669-1', gtag_config);
+	})();
+</script>
+
+
+
+
+<script src="https://img.finalfantasyxiv.com/lds/pc/en-gb/js/i18n.js?1642399092"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/i/2ur_0e4qXk_NwNv0bGjrUHThCM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/g/uQNBgvCaabd4gw5kMpaT-psp1Q.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/b/RKD_bGx738E81TyiPQN4kGf-_Y.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/Z/wqo4GxX1wALdnxx6xOv38NxFVY.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/e/TSPHxkEhdcyaPMm0rpoBtk1dZA.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/P/O9-IKBqOphhkhVvm2QPrR9x5p4.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/9/TTeYt1mN0BF3R1Av3fWlknchv4.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/8/b_tPmOnEw1tyr2dp2InkGxUlMA.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/Y/6WaukM6m3WFE2JXrCEb6tsknik.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/E/ImNUSWkI-O9dQP5ADa41RiGxGY.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/t/kQLYFR8rOESAOiyT9o2PsRnLq0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/C/q1cplyit_St5sY1BUgBKFuLapM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/s/Gt4XmT3a3nu52yKZPoVWcvrfFM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/A/LATlIIBarKmGFTTVid87k_GPFg.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/W/r-0ziwRwdsVj1lEyFHfmVyFgKw.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/piXyeCeUEtNAzCIq6jXoqNimzE.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/t/85HyWVlETnECMXo9l40HahjdO0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/OIfkF0BnyASNQ0RswButWbIKCU.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/U/jhEwPt7MvJy47-ExjjZ3lHW3qI.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/0/f52zA7ACWvjEMB1oWe8kfyGWH0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/l/-_ePiHXNE_1t8LnRcmRAbhRME8.js"></script>
+<script src="https://www.youtube.com/iframe_api"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/P/MYGDtxveSuUwuhprm8oj1Hhuq8.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/it7tc9wvjlJJstEQUNjiModhdM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/n/HMQm8_JEoqrSmuv5RmmKgTldGc.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/B/ElvNJhxzt4ULBYHMPrt3JiAKGU.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/d/UfPsCOe_Nl7ytqem4KWdsftkY0.js"></script>
+
+
+<div id="dialog_bg" style="opacity:0; visibility: hidden;"></div>
+<!-- dialog -->
+<div name="ldstDialog" class="overlay__area js__overlay" style="opacity:0; visibility: hidden; top: 0px">
+	<p class="overlay__text--icon"></p>
+
+	<div class="outbound_consent hide">
+		<input type="checkbox" name="outbound_consent" value="1" id="outbound_consent" class="form__checkbox">
+		<label for="outbound_consent" class="form__checkbox__label form__outbound">
+			Do not show this message again.
+		</label>
+	</div>
+
+	<!-- SIMPLE DIALOG -->
+	<a href="javascript:void(0);" class="js__dialog_btn btn__color--radius js__overlay_ok">Confirm</a>
+	<!-- //SIMPLE DIALOG -->
+	<!-- CONFIRM DIALOG -->
+	<ul class="js__dialog_btn overlay__btn js__overlay_btn">
+		<li><a href="javascript:void(0);" class="js__overlay_yes">Yes</a></li>
+		<li><a href="javascript:void(0);" class="js__overlay_no">No</a></li>
+	</ul>
+	<!-- //CONFIRM DIALOG -->
+</div>
+<!-- //dialog -->
+
+
+
+
+</body>
+</html>

--- a/src/test/resources/data/lodestone/Character-33000061-Mounts.html
+++ b/src/test/resources/data/lodestone/Character-33000061-Mounts.html
@@ -1,0 +1,1320 @@
+<!DOCTYPE html>
+<html lang="en-gb" class="en-gb" xmlns:og="http://ogp.me/ns#" xmlns:fb="http://www.facebook.com/2008/fbml">
+<head><meta charset="utf-8">
+
+	<!-- Google Tag Manager -->
+	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	})(window,document,'script','digitalData','GTM-P37XSWJ');</script>
+	<!-- End Google Tag Manager -->
+
+	<title>Ivis Castalia | FINAL FANTASY XIV, The Lodestone</title>
+	<meta name="description" content="Character profile for Ivis Castalia.">
+	<meta name="keywords" content="FF14,FFXIV,Final Fantasy XIV,Final Fantasy 14,Lodestone,players' site,community site,A Realm Reborn,Heavensward,Stormblood,Shadowbringers,Endwalker,MMO">
+	<meta name="author" content="SQUARE ENIX Ltd.">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="format-detection" content="telephone=no">
+
+	<link rel="shortcut icon" type="image/vnd.microsoft.icon" href="https://img.finalfantasyxiv.com/lds/pc/global/images/favicon.ico?1490749553">
+	<link rel="apple-touch-icon-precomposed" href="https://img.finalfantasyxiv.com/lds/h/0/U2uGfVX4GdZgU1jASO0m9h_xLg.png">
+	<meta name="msapplication-TileImage" content="https://img.finalfantasyxiv.com/lds/h/0/U2uGfVX4GdZgU1jASO0m9h_xLg.png">
+
+	<meta name="msapplication-TileColor" content="#000000">
+	<link rel="alternate" hreflang="ja" href="https://jp.finalfantasyxiv.com/lodestone/character/33000061/mount/">
+	<link rel="alternate" hreflang="en-us" href="https://na.finalfantasyxiv.com/lodestone/character/33000061/mount/">
+	<link rel="alternate" hreflang="fr" href="https://fr.finalfantasyxiv.com/lodestone/character/33000061/mount/">
+	<link rel="alternate" hreflang="de" href="https://de.finalfantasyxiv.com/lodestone/character/33000061/mount/">
+
+
+	<meta name="google-site-verification" content="WwpBRGfcVWgP_LxTs8PHc6EcDM8eCt8Zqck1MAnVmZM">
+
+
+
+
+	<!--[if lt IE 9]>
+	<script src="https://img.finalfantasyxiv.com/lds/h/I/SMlNRnAvuilc1lYKBpzKWpmADs.js"></script>
+
+	<![endif]-->
+	<!-- ** CSS ** -->
+	<link href="https://img.finalfantasyxiv.com/lds/h/M/0kxkkawCCBg1ArBrU_c1cydINM.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/-/tUrZCLFtMgzaHil2OXxbmdw2a0.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/l/6D7j33OWZQd8eVk8IKWT15deH8.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/j/JgAulXN0McN_xRNcKLLbnNh4fs.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/F/wZHqGlYFe-0or10VJJtARsKyko.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/a/bmAvctt6TxsMwvFeI4NiKcWnZM.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/Q/mAASajjDE39sDOGkuOPDZPBt0s.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/w/YgRYdK0dq3N9UCU6nR-7J5PftA.css" rel="stylesheet">
+
+	<link href="https://img.finalfantasyxiv.com/lds/h/b/tInX1HM2lXTimf4ts8i-7wWr1Y.css" rel="stylesheet">
+
+	<link href="https://img.finalfantasyxiv.com/lds/h/w/cuKVxIZUo5Tf3xQ8a9_mn8jZDU.css" rel="stylesheet"
+		  class="sys_theme_css"
+
+		  data-theme_white="https://img.finalfantasyxiv.com/lds/h/w/cuKVxIZUo5Tf3xQ8a9_mn8jZDU.css"
+
+		  data-theme_black="https://img.finalfantasyxiv.com/lds/h/o/q3zLnccpt9t--buuJJqeuTpzOY.css"
+
+	>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<!-- ogp -->
+	<meta property="fb:app_id" content="1400886233468625">
+	<meta property="og:type" content="website">
+	<meta property="og:description" content="Character profile for Ivis Castalia.">
+	<meta property="og:title" content="Ivis Castalia | FINAL FANTASY XIV, The Lodestone">
+	<meta property="og:url" content="https://eu.finalfantasyxiv.com/lodestone/character/33000061/mount/">
+	<meta property="og:site_name" content="FINAL FANTASY XIV, The Lodestone">
+	<meta property="og:locale" content="en_GB">
+
+	<meta property="og:image" content="https://img.finalfantasyxiv.com/lds/h/I/cy_FoBlOdFg3kBAQdaAxT19pTw.png">
+
+
+
+	<meta property="fb:pages" content="116214575870">
+
+
+	<meta name="twitter:card" content="summary_large_image">
+
+	<meta name="twitter:site" content="@ff_xiv_en">
+
+
+
+
+	<script>
+		var base_domain = 'finalfantasyxiv.com';
+		var ldst_subdomain = 'eu';
+		var strftime_fmt = {
+			'dateHHMM_now': 'Today %H:%M',
+			'dateYMDHMS': '%d/%m/%Y %H:%M:%S',
+			'dateYMDHM': '%d/%m/%Y %H:%M',
+			'dateYMDHM_jp': '%Y/%m/%d %H:%M',
+			'dateHM': '%H:%M',
+			'dateYMDH': '%d/%m/%Y %H',
+			'dateYMD': '%d/%m/%Y',
+			'dateEternal': '%d.%m.%Y',
+			'dateYMDW': '%d/%m/%Y (%a)',
+			'dateHM': '%H:%M',
+			'week.0': 'Sun.',
+			'week.1': 'Mon.',
+			'week.2': 'Tue.',
+			'week.3': 'Wed.',
+			'week.4': 'Thu.',
+			'week.5': 'Fri.',
+			'week.6': 'Sat.'
+		};
+		var base_uri   = '/lodestone/';
+		var api_uri    = '/lodestone/api/';
+		var static_uri = 'https://img.finalfantasyxiv.com/lds/';
+		var subdomain  = 'eu';
+		var csrf_token = 'b726b2475aab6e2b29c16ddcf48f50e5e7d76211';
+		var cis_origin = 'https://secure.square\u002denix.com';
+		var ldst_max_image_size = 31457280;
+		var eorzeadb = {
+			cdn_prefix: 'https://img.finalfantasyxiv.com/lds/',
+			version: '1641278251',
+			version_js_uri:  'https://img.finalfantasyxiv.com/lds/pc/global/js/eorzeadb/version.js',
+			dynamic_tooltip: false
+		};
+		var cookie_suffix = '';
+		var ldst_is_loggedin = false;
+		var show_achievement = false;
+	</script>
+	<script src="https://img.finalfantasyxiv.com/lds/h/A/PknAmzDJUZCNhTGtSGGMIGi5k4.js"></script>
+	<script src="https://img.finalfantasyxiv.com/lds/h/H/hBuD3_ZXTqwHX64YYCchtvgGSs.js"></script>
+
+
+
+
+
+
+
+
+
+</head>
+<body id="community" class=" lang_eu">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P37XSWJ"
+				  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+
+
+
+<div class="brand"><div class="brand__section">
+	<div class="brand__logo">
+		<a href="
+				https://square-enix-games.com/en_GB
+			" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/h/L/cxcD5kjeM52JRVwrrzIF4dZNe0.png" width="130" height="14" alt="SQUARE ENIX">
+		</a>
+	</div>
+
+
+	<div class="brand__search">
+		<form action="/lodestone/community/search/" class="brand__search__form">
+			<div class="brand__search__focus_bg"></div>
+			<div class="brand__search__base_bg"></div>
+			<input type="text" id="txt_search" class="brand__search--text" name="q" placeholder="Search">
+			<input type="submit" id="bt_search" class="brand__search--btn" value="">
+		</form>
+	</div>
+
+
+
+	<div class="brand__theme sys_theme_switcher">
+		<a href="javascript:void(0);"><i class="brand__theme--white sys_theme active js__tooltip" data-tooltip="Theme (Black)" data-theme="white"></i></a>
+		<a href="javascript:void(0);"><i class="brand__theme--black sys_theme js__tooltip" data-tooltip="Theme (White)" data-theme="black"></i></a>
+	</div>
+
+
+	<div class="brand__lang dropdown_trigger_box">
+		<a href="javascript:void(0);" class="brand__lang__btn brand__lang__en-gb dropdown_trigger">English</a>
+		<ul class="brand__lang__select dropdown">
+
+			<li><a href="https://jp.finalfantasyxiv.com/lodestone/character/33000061/mount/" class="brand__lang__jp">日本語</a></li>
+
+			<li><a href="https://na.finalfantasyxiv.com/lodestone/character/33000061/mount/" class="brand__lang__na">English</a></li>
+
+			<li><a href="https://eu.finalfantasyxiv.com/lodestone/character/33000061/mount/" class="brand__lang__eu">English</a></li>
+
+			<li><a href="https://fr.finalfantasyxiv.com/lodestone/character/33000061/mount/" class="brand__lang__fr">Français</a></li>
+
+			<li><a href="https://de.finalfantasyxiv.com/lodestone/character/33000061/mount/" class="brand__lang__de">Deutsch</a></li>
+
+		</ul>
+	</div>
+
+
+
+	<div class="l__cross_menu eu">
+		<a href="javascript:void(null)" class="ffxiv_pr_cross_menu_button_eu"></a>
+		<script>
+			var ffxiv_pr_cross_menu = {
+				uri_js: '/cross_menu/uri.js'
+			};
+		</script>
+		<script src="https://img.finalfantasyxiv.com/lds/promo/pc/global/menu/loader.js"></script>
+	</div>
+
+</div></div>
+
+
+
+
+<header class="l__header">
+	<div class="l__header__inner l__header__bg_image" style="background-image: url(https://img.finalfantasyxiv.com/lds/banner/1074/headerImage_6_0_eu.jpg);">
+		<a href="/lodestone/" class="l__header__link_top"></a>
+
+
+		<a href="/lodestone/topics/detail/66a742165e9415790247c1a1f7d909abf5becb5c/?utm_source=lodestone&amp;utm_medium=pc_header&amp;utm_campaign=eu_6_0patch" class="l__header__link_management"></a>
+
+
+		<div class="l__header__login clearfix"><a href="/lodestone/account/login/" class="l__header__login__btn">
+			<img src="https://img.finalfantasyxiv.com/lds/h/z/6PLTZ82M99GJ7tKOee1RSwvNrQ.png" width="40" height="40" alt="" class="l__header__login__chara_silhouette">
+			<div class="l__header__login__txt">
+				<p>View Your Character Profile</p>
+				<div>Log In</div>
+			</div>
+		</a></div>
+
+
+	</div>
+</header>
+
+
+
+
+
+
+
+
+
+
+<div class="global-nav">
+	<nav class="main-nav eu">
+		<ul class="main-nav__area main-nav__area__community clearfix ">
+			<li class="main-nav__news main-nav__item">
+				<a href="/lodestone/news/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_news-top');"><span>News</span></a>
+				<nav class="sub-nav">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__news">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__news__icon">
+									<li>
+										<a href="/lodestone/news/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_top');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/8/2GwuzUcvqLa-hgQeLUyd8xarI8.png" width="32" height="32" alt="News">
+											News
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/topics/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_topics');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/5/67ZyAIzQUaYoWBmyvFwNvGmCnQ.png" width="32" height="32" alt="Topics">
+											Topics
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/1" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_notices');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/-/Y5JdwnEWYfyO7OlH27eKIm91Ok.png" width="32" height="32" alt="Notices">
+											Notices
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/2" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_maintenance');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/s/-JfULvMAf26L7AaU1OGaGYwanI.png" width="32" height="32" alt="Maintenance">
+											Maintenance
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/3" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_updates');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/p/HPudyOQcwdv97RBwj3FQC552ps.png" width="32" height="32" alt="Updates">
+											Updates
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/4" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_Status');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/S/-IC2xIQhTl2ymYW7deE1fOII04.png" width="32" height="32" alt="Status">
+											Status
+										</div></a>
+									</li>
+								</ul>
+								<ul class="sub-nav__news__text">
+									<li><a href="/lodestone/special/patchnote_log/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_patch-notes_special-sites');"><div>
+										Patch Notes and Special Sites
+										<span class="update">
+											Updated <span id="datetime-8f6fab86d8a">-</span><script>document.getElementById('datetime-8f6fab86d8a').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</div></a></li>
+									<li><a href="/lodestone/special/update_log/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_lodestone-update-notes');"><div>
+										<span class="sub_text">Official Community Site</span>
+										The Lodestone Update Notes
+										<span class="update">
+											Updated <span id="datetime-a782d83a2c9">-</span><script>document.getElementById('datetime-a782d83a2c9').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</div></a></li>
+									<li><a href="/lodestone/worldstatus/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_server-status');"><div>
+										Server Status
+									</div></a></li>
+								</ul>
+							</div>
+						</div>
+
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__promotion main-nav__item">
+				<a href="/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_begin-ff14-top');"><span>Getting Started</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__promotion">
+							<div class="sub-nav__list__inner">
+								<div class="sub-nav__promotion__inner">
+									<div class="sub-nav__promotion__link">
+										<div class="sub-nav__promotion__top">
+											<a href="/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_pr');"><img src="https://img.finalfantasyxiv.com/lds/h/P/ciPXy1S4-ssQuLQJvEF4JWVm5Q.jpg" width="632" height="140" alt="FINAL FANTASY XIV: A Realm Reborn"></a>
+										</div>
+										<ul class="sub-nav__promotion__page">
+											<li><a href="/benchmark/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_benchmark');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/S/2_8ofX4E90a7pS-p0mjFK_tc_U.png" width="64" height="40" alt="Benchmark">
+												<span>Benchmark</span>
+											</a></li>
+											<li><a href="
+
+													http://freetrial.finalfantasyxiv.com/
+												" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_freetrial');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/c/tWvZpXDc_g6yQd5YKK2k5jhuns.png" width="64" height="40" alt="Free Trial">
+												<span>Free Trial</span>
+											</a></li>
+											<li><a href="/product/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_product');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/m/NCNLGrn3U9M85ky-NscraujvN8.png" width="64" height="40" alt="Product">
+												<span>Product</span>
+											</a></li>
+											<li><a href="/winning/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_awards');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/j/udWU20sWmhYoEsQ_FtrAzVwJ3Q.png" width="64" height="40" alt="Awards and Nominations">
+												<span>Awards and Nominations</span>
+											</a></li>
+										</ul>
+									</div>
+									<div class="sub-nav__promotion__patch_site">
+										<a href="/endwalker/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_latest-expansion');"><span>
+											<img src="https://img.finalfantasyxiv.com/lds/h/f/sLzgsq-NNdSMdqLt6Mby4oROC0.png" width="296" height="232" alt="FINAL FANTASY XIV: Endwalker Special Site">
+										</span></a>
+									</div>
+								</div>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+			</li>
+			<li class="main-nav__playguide main-nav__item">
+				<a href="/lodestone/playguide/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_playguide-top');"><span>Play Guide</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__playguide">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__playguide__list">
+									<li><a href="/lodestone/playguide/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_playguide-top');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/P/Lfl3LVb9KMPa5Ye8yxftZkelbc.png" width="40" height="40" alt="Play Guide<br />Top">
+										<span>Play Guide<br />Top</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#game_playguide" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_game-playguide');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/q/qy4dUGMNkjoyVqPweYMIpOApik.png" width="40" height="40" alt="Gameplay Guide and<br />Beginners' Guide">
+										<span>Gameplay Guide and<br />Beginners' Guide</span>
+										<span class="update">
+											Updated <span id="datetime-7a1da2f2388">-</span><script>document.getElementById('datetime-7a1da2f2388').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/db/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_databese');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/N/OYPWhQVCkovUbVcMMck0O4HABU.png" width="40" height="40" alt="Eorzea Database">
+										<span>Eorzea Database</span>
+										<span class="update">
+											Updated <span id="datetime-d736ece73ce">-</span><script>document.getElementById('datetime-d736ece73ce').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#content_guide" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_contents-guide');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/W/wlHP1NMpdQHcPKUG-swlv71fhE.png" width="40" height="40" alt="Game Features">
+										<span>Game Features</span>
+										<span class="update">
+											Updated <span id="datetime-2c61cbb0203">-</span><script>document.getElementById('datetime-2c61cbb0203').innerHTML = ldst_strftime(1638518400, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#side_storyes" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_side-story');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/Z/1QWgBsVU7ZboWyMZlRjCQcDRJg.png" width="40" height="40" alt="Side Stories<br />and More">
+										<span>Side Stories<br />and More</span>
+										<span class="update">
+											Updated <span id="datetime-a23c3fbdcdf">-</span><script>document.getElementById('datetime-a23c3fbdcdf').innerHTML = ldst_strftime(1632470400, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#option_service" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_option-service');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/4fXwcEoJzDEmFRt-tD7PeeKvjE.png" width="40" height="40" alt="Additional Services">
+										<span>Additional Services</span>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__community main-nav__item">
+				<a href="/lodestone/community/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_community-top');"><span>Community</span></a>
+				<nav class="sub-nav">
+					<div class="sub-nav__area">
+
+
+						<div class="sub-nav__list sub-nav__community">
+							<div class="sub-nav__list__inner sub-nav__community__flex">
+								<div class="sub-nav__community__link">
+									<div class="sub-nav__community__top">
+										<div class="sub-nav__community__top__wrapper">
+											<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/q/GiEpnP3oCXluFjrlPlM-mgIbS8.png" width="16" height="16" alt="Community">Community</h2>
+											<ul class="sub-nav__community__list">
+												<li><a href="/lodestone/community/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_community-top');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/i/Sa5YF2-VFf4IJ1cjjFAbPf4GWg.png" width="40" height="40" alt="Community Wall">
+													<span>Community Wall</span>
+												</a></li>
+												<li><a href="/lodestone/blog/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_blog');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/h/6gPbLbzUQ_omC_mdXFUA3zPy7I.png" width="40" height="40" alt="Blog">
+													<span>Blog</span>
+												</a></li>
+											</ul>
+										</div>
+										<div class="sub-nav__community__top__wrapper">
+											<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/d/in_Sbc6SzxLU--Npa7URI-_kdg.png" width="16" height="16" alt="Member Recruitment">Member Recruitment</h2>
+											<ul class="sub-nav__community__list">
+												<li><a href="/lodestone/community_finder/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_community-finder');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/V/kHxwEjpY-Fme83ta8VIfi1kyLU.png" width="40" height="40" alt="Community Finder">
+													<span>Community Finder</span>
+												</a></li>
+												<li><a href="/lodestone/event/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_event-party');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/0/k5jD6-BJZHwKA2CtbNcDYZR6oY.png" width="40" height="40" alt="Event & Party Recruitment">
+													<span>Event & Party Recruitment</span>
+												</a></li>
+											</ul>
+										</div>
+									</div>
+									<div class="sub-nav__community__search">
+										<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/X/uQVT3DEl1xlFWHu3UZU4-RBtVk.png" width="16" height="16" alt="Search">Search</h2>
+										<ul class="sub-nav__community__list sub-nav__community__search__list">
+											<li><a href="/lodestone/character/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_chara-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/5/YcEF3K-5SgqU0BxZtT0D1Zsa2A.png" width="40" height="40" alt="Character Search">
+												<span>Character Search</span>
+											</a></li>
+											<li><a href="/lodestone/linkshell/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_ls-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/b/SPCgcBAk4HvMngGzk6H4MfSINg.png" width="40" height="40" alt="Linkshell Search">
+												<span>Linkshell Search</span>
+											</a></li>
+											<li><a href="/lodestone/crossworld_linkshell/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_cwls-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/L/NUGcPcy-C8jvx6oKgEXgwJ1ePE.png" width="40" height="40" alt="CWLS Search ">
+												<span>CWLS Search </span>
+											</a></li>
+											<li><a href="/lodestone/freecompany/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_fc-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/q/GJ-lsgAtsCCDwCm9te3a5sCjpU.png" width="40" height="40" alt="Free Company Search">
+												<span>Free Company Search</span>
+											</a></li>
+											<li><a href="/lodestone/pvpteam/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_pvp-team-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="PvP Team Search">
+												<span>PvP Team Search</span>
+											</a></li>
+										</ul>
+									</div>
+								</div>
+								<div class="sub-nav__community__side">
+									<div class="sub-nav__community__forum">
+										<ul class="sub-nav__community__forum__list">
+											<li><a href="https://forum.square-enix.com/ffxiv/forum.php" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum');">
+												<div class="forum">
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/r/maZ-sHaqn4PMFANUlbH4GzztFM.png" width="40" height="40" alt="Forums">
+													</i><span>Forums</span>
+												</div>
+											</a></li>
+											<li><a href="https://forum.square-enix.com/ffxiv/search.php?do=getdaily_ll&contenttype=vBForum_Post" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum-new-posts');">
+												<div>
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+													</i><span>New Posts</span>
+												</div>
+											</a></li>
+											<li><a href="
+
+														https://forum.square-enix.com/ffxiv/search.php?do=process&search_type=1&contenttypeid=1&devtrack=1&starteronly=0&showposts=1&childforums=1&forumchoice[]=619
+													" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum-dev-tracker');">
+												<div>
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+													</i><span>Dev Tracker</span>
+												</div>
+											</a></li>
+										</ul>
+									</div>
+									<ul class="sub-nav__community__fankit">
+										<li><a href="/lodestone/special/fankit/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_fankit');">
+											<div>
+												<span>Fan Kit</span>
+												<span class="update">
+													Updated <span id="datetime-c8ae3edbc7f">-</span><script>document.getElementById('datetime-c8ae3edbc7f').innerHTML = ldst_strftime(1640332800, 'YMD');</script>
+												</span>
+											</div>
+										</a></li>
+									</ul>
+								</div>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__ranking main-nav__item">
+				<a href="/lodestone/ranking/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_ranking-top');"><span>Standings</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__ranking">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__ranking__list">
+									<li><a href="/lodestone/ranking/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_ranking-top');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/E/NtymEFiUJfAh25ffTrADsVFkLQ.png" width="40" height="40" alt="Standings Top">
+										<span>Standings Top</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/thefeast/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_feast');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="The Feast Rankings">
+										<span>The Feast Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/deepdungeon2/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_deepdungeon2');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/_/qP22LgUoAFKDTRayb_TEYu6d7g.png" width="40" height="40" alt="Heaven-on-High Rankings">
+										<span>Heaven-on-High Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/deepdungeon/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_deepdungeon');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/p/op9iPrlMmYgTK3Q6NQKifyQOGA.png" width="40" height="40" alt="Palace of the Dead Rankings">
+										<span>Palace of the Dead Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/frontline/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_frontline');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="Frontline Standings">
+										<span>Frontline Standings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/gc/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_gc');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/o/uRmujlTx4X_5c6wETNxssK1d_4.png" width="40" height="40" alt="Grand Company Standings">
+										<span>Grand Company Standings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/fc/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_fc');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/q/GJ-lsgAtsCCDwCm9te3a5sCjpU.png" width="40" height="40" alt="Free Company Standings">
+										<span>Free Company Standings</span>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__help main-nav__item">
+				<a href="/lodestone/help/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_help-support-top');"><span>Help & Support</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__help">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__help__list">
+									<li><a href="/lodestone/help/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_help-support-top');">
+										<span>Help & Support</span>
+									</a></li>
+									<li><a href="/lodestone/help/about_the_lodestone/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_about-lodestone');">
+										<span>About the Lodestone</span>
+									</a></li>
+									<li><a href="
+
+											https://support.eu.square-enix.com/faq.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_faq');">
+										<span>FAQ</span>
+									</a></li>
+									<li><a href="
+
+											https://eu.square-enix.com/en/seaccount/
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_sqex-account');">
+										<span>Square Enix Account Information</span>
+									</a></li>
+								</ul>
+								<ul class="sub-nav__help__other">
+									<li><a href="
+
+											https://support.eu.square-enix.com/rule.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_rule-policies');">
+										<div>
+											<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+											</i><span>Rules & Policies</span>
+										</div>
+									</a></li>
+									<li><a href="
+
+											https://support.eu.square-enix.com/main.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_customer-service');">
+										<div>
+											<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+											</i><span>Customer Service</span>
+										</div>
+									</a></li>
+									<li><a href="https://sqex.to/Msp" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_mogstation');">
+										<div>
+											<i class="ic_mogst"><img src="https://img.finalfantasyxiv.com/lds/h/S/6IKp0hN6xQqTYPgnPIsd2fjzSI.png" width="32" height="32" alt="">
+											</i><span>Mog Station</span>
+										</div>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+		</ul>
+	</nav>
+</div>
+
+
+
+
+<div class="ldst__bg">
+
+	<div id="breadcrumb">
+		<ul itemscope itemscope itemtype="https://schema.org/BreadcrumbList" class="clearfix">
+			<li class="breadcrumb__home" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/" itemprop="item"><span itemprop="name">HOME</span></a>
+				<meta itemprop="position" content="1" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/community/" itemprop="item" class="breadcrumb__link"><span itemprop="name">Community</span></a>
+				<meta itemprop="position" content="2" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/character/" itemprop="item" class="breadcrumb__link"><span itemprop="name">Character</span></a>
+				<meta itemprop="position" content="3" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<span itemprop="name">Ivis Castalia</span>
+				<meta itemprop="position" content="4" />
+			</li>
+
+
+		</ul>
+	</div>
+
+
+	<h1 class="heading__title">Character</h1>
+
+
+
+	<nav class="btn__corner_block">
+		<ul class="btn__corner_block--3">
+
+			<li>
+				<a href="/lodestone/character/33000061/" class="btn__menu btn__menu--active">Profile</a>
+			</li>
+			<li>
+				<a href="/lodestone/character/33000061/blog/" class="btn__menu">Blog</a>
+			</li>
+			<li>
+				<a href="/lodestone/character/33000061/event/" class="btn__menu">Events</a>
+			</li>
+
+		</ul>
+	</nav>
+
+
+
+	<div class="ldst__contents clearfix">
+
+		<div class="ldst__main">
+
+
+
+
+			<div id="character" class="ldst__window">
+				<h2 class="heading--lg">Character</h2>
+
+
+
+				<div class="frame__chara js__toggle_wrapper">
+					<a href="/lodestone/character/33000061/" class="frame__chara__link">
+						<div class="frame__chara__face">
+							<img src="https://img2.finalfantasyxiv.com/f/c89729f713c11518b5f0b660bdd42b41_96ab1df8877c1f8ba6a89a39cccfd437fc0_96x96.jpg?1642765243" width="40" height="40" alt="">
+						</div>
+						<div class="frame__chara__box">
+
+							<p class="frame__chara__name">Ivis Castalia</p>
+
+							<p class="frame__chara__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Cactuar&nbsp;(Aether)</p>
+						</div>
+					</a>
+					<div class="parts__connect--state js__toggle_trigger">
+
+
+						<i class="parts__connect_off js__tooltip" data-tooltip="You have no connection with this character."></i>
+
+					</div>
+
+					<div class="parts__switch js__toggle_item">
+
+						<p class="character__connect__text">You have no connection with this character.</p>
+
+
+
+
+
+						<div class="heading--md-slide">Follower Requests</div>
+						<p class="entry__toggle__text">Before this character can be followed, you must first submit a follower request.<br />Do you wish to proceed?</p>
+						<ul class="btn__switch character__connect__form">
+							<li><a href="/lodestone/account/login/">Yes</a></li>
+							<li><a href="javascript:void(0)" class="js__toggle_trigger">No</a></li>
+						</ul>
+
+
+
+					</div>
+
+				</div>
+
+				<ul class="character__profile_tab js__character_menu clearfix"><li><a href="/lodestone/character/33000061/#profile">Profile</a></li><li class="character_menu__link"><a href="/lodestone/character/33000061/class_job/">Class/Job</a></li><li class="disable"><span class="disable">Minions</span></li><li class="character_menu__link"><a href="javascript:void(null)" class="selected">Mounts</a></li><li class="character_menu__link"><a href="/lodestone/character/33000061/following/">Follow</a></li></ul>
+
+
+
+
+				<div class="character__content selected">
+
+					<h3 class="heading--md">Mounts</h3>
+
+					<div class="mount__sort">
+
+						<p class="minion__sort__total">Total: <span>1</span></p>
+					</div>
+
+					<div class="character__mounts">
+						<ul class="character__icon__list js__mount_tooltip js__mount_list">
+							<li class="mount__list_icon"data-tooltip_href="/lodestone/character/33000061/mount/tooltip/cfe0f418510278f7e1402584896223387858049b"><div class="character__item_icon"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/2e/2edca9a0c233da977338b307e81842a64852ba86.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon--frame"></div><img src="https://img.finalfantasyxiv.com/lds/h/H/460ZBYyhODi1RNXXV-1hck8V40.png" width="48" height="48" alt="" class="character__item_icon__hover"></div></li>
+						</ul>
+					</div>
+
+				</div>
+			</div>
+		</div>
+
+		<div class="ldst__side">
+
+
+
+
+			<div class="l__rside__bnr clearfix">
+				<a href="https://forum.square-enix.com/ffxiv/forum.php?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_forum" target="_blank" class="l__rside__bnr--forums"><img src="https://img.finalfantasyxiv.com/lds/h/i/i3r6u3moBzQFfijSTu9k3EJirQ.png" width="100" height="62" alt="Forums"></a><a href="https://sqex.to/Msp?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_mogstation" target="_blank" class="l__rside__bnr--mog_station"><img src="https://img.finalfantasyxiv.com/lds/h/3/GjsnqfVxPQrE4Jve8GvKZABF5w.png" width="100" height="62" alt="Mog Station"></a><a href="/pr/blog/?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_officalblog" target="_blank" class="l__rside__bnr--blog"><img src="https://img.finalfantasyxiv.com/lds/h/d/nVeXvIIStLv3npokivV0EzkKwI.png" width="100" height="62" alt="Official Blog"></a>
+			</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+			<div class="mb10"><a href="/endwalker/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_endwalker"><img src="https://img.finalfantasyxiv.com/lds/banner/998/v60_211207_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="https://store.finalfantasyxiv.com/ffxivstore/en-gb/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_onlinestore" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/banner/916/LDS_ffxivos_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/special/2022/All_Saints_Wake/rjk7wevhuy?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_all_saints_wake"><img src="https://img.finalfantasyxiv.com/lds/banner/1119/mnbn_all_saints_wake-1_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/community_finder/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_cf202112"><img src="https://img.finalfantasyxiv.com/lds/banner/1104/LDS_CF_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/jobguide/battle/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_jobguide"><img src="https://img.finalfantasyxiv.com/lds/banner/1089/jobguide_v60_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/uiguide/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_uiguide"><img src="https://img.finalfantasyxiv.com/lds/banner/671/pc_uiguide_eu.jpg"></a></div>
+
+
+
+			<div class="conducting_area">
+
+				<img src="https://img.finalfantasyxiv.com/lds/h/z/EhLfs3eya3Aidfr8A6PbXOBgtA.png" width="300" height="218" alt="">
+
+				<div class="inr">
+					<a href="
+				http://freetrial.finalfantasyxiv.com/" class="bt_conducting">
+						<img src="https://img.finalfantasyxiv.com/lds/h/s/3KRua4vzZJvRXn0IMk8Da103bw.png" width="284" height="80" alt="Start Your Free Trial">
+					</a>
+					<a href="/product/?utm_source=lodestone&utm_medium=pc_buyarea&utm_campaign=eu_buynow" class="bt_conducting" target="_blank">
+						<img src="https://img.finalfantasyxiv.com/lds/h/p/to8CzK_gktAHpLuSGzCkNdLfWo.png" width="284" height="80" alt="BUY NOW!">
+					</a>			<a href="https://support.eu.square-enix.com/faqarticle.php?id=5383&la=2&kid=78775" onmousedown="ga('send', 'event', 'lodestone_eu', 'howtoupgrade_link', 'EU-lodestone-UG_20170620', true);" class="bt_ft_migration">			<img src="https://img.finalfantasyxiv.com/lds/h/0/5rrJdYAcP3if6zX6d62dHV3t34.png" width="260" height="80" alt="Upgrade Your Free Trial<br />to the Full Version">
+				</a>
+				</div>
+			</div>
+
+
+
+
+
+
+
+
+
+			<div class="mb10"><a href="/tales_of_adventure/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_tales_of_adventure"><img src="https://img.finalfantasyxiv.com/lds/banner/1079/LDS_Tales_of_Adventure_v60_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/special/friend_recruit/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_friendrecruit"><img src="https://img.finalfantasyxiv.com/lds/banner/203/bn_Recruit_a_Friend_eu.png"></a></div>
+
+
+
+
+
+
+			<div class="ldst__side__box">
+
+
+
+				<div class="heading--side">
+					<h3>Community Wall</h3>
+					<a href="/lodestone/community/" class="heading--side__icon icon-list__side js__tooltip" data-tooltip="See More"></a>
+				</div>
+				<div class="heading__icon parts__space--reset js__toggle_wrapper">
+					<h4>Recent Activity</h4>
+					<i class="icon-btn__filter js__toggle_trigger js__tooltip" data-tooltip="Filter"></i>
+					<div class="parts__switch parts__switch--filter js__toggle_item">
+						<p class="parts__text">
+							Filter which items are to be displayed below.<br>
+							<span class="parts__text__notes">
+				* Notifications for standings updates are shared across all Worlds.<br>
+				* Notifications for PvP team formations are shared for all languages.<br>
+				* Notifications for free company formations are shared for all languages.
+			</span>
+						</p>
+
+
+						<div class="form__horizontal js__communitywall_filter">
+							<input type="hidden" name="order" value=""><h5 class="heading--side--lead">Sort by</h5><ul class="form__row parts__spce--8"><li><input type="checkbox" name="community_type" value="blog" class="form__checkbox" id="community_type01"><label class="form__checkbox__label" for="community_type01">Blog</label></li><li><input type="checkbox" name="community_type" value="event" class="form__checkbox" id="community_type02"><label class="form__checkbox__label" for="community_type02">Event & Party Recruitment</label></li><li><input type="checkbox" name="community_type" value="fc" class="form__checkbox" id="community_type03"><label class="form__checkbox__label" for="community_type03">Free Company</label></li><li><input type="checkbox" name="community_type" value="db" class="form__checkbox" id="community_type04"><label class="form__checkbox__label" for="community_type04">Eorzea Database</label></li><li><input type="checkbox" name="community_type" value="ranking" class="form__checkbox" id="community_type05"><label class="form__checkbox__label" for="community_type05">Standings</label></li><li><input type="checkbox" name="community_type" value="pvpteam" class="form__checkbox" id="community_type06"><label class="form__checkbox__label" for="community_type06">PvP Team</label></li><li><input type="checkbox" name="community_type" value="community_finder" class="form__checkbox" id="community_type07"><label class="form__checkbox__label" for="community_type07">Community Finder</label></li></ul><h5 class="heading--side--lead">Data Center / Home World</h5><div class="select-pulldown"><label class="control-label" for="world"></label><select name="community_worldname" class="select-pulldown__open"><option value="">Select All</option><optgroup label="Data Center"><option value="_dc_Elemental">Elemental</option><option value="_dc_Gaia">Gaia</option><option value="_dc_Mana">Mana</option><option value="_dc_Aether">Aether</option><option value="_dc_Primal">Primal</option><option value="_dc_Crystal">Crystal</option><option value="_dc_Chaos">Chaos</option><option value="_dc_Light">Light</option></optgroup><optgroup label="Home World"><option value="Adamantoise">Adamantoise</option><option value="Aegis">Aegis</option><option value="Alexander">Alexander</option><option value="Anima">Anima</option><option value="Asura">Asura</option><option value="Atomos">Atomos</option><option value="Bahamut">Bahamut</option><option value="Balmung">Balmung</option><option value="Behemoth">Behemoth</option><option value="Belias">Belias</option><option value="Brynhildr">Brynhildr</option><option value="Cactuar">Cactuar</option><option value="Carbuncle">Carbuncle</option><option value="Cerberus">Cerberus</option><option value="Chocobo">Chocobo</option><option value="Coeurl">Coeurl</option><option value="Diabolos">Diabolos</option><option value="Durandal">Durandal</option><option value="Excalibur">Excalibur</option><option value="Exodus">Exodus</option><option value="Faerie">Faerie</option><option value="Famfrit">Famfrit</option><option value="Fenrir">Fenrir</option><option value="Garuda">Garuda</option><option value="Gilgamesh">Gilgamesh</option><option value="Goblin">Goblin</option><option value="Gungnir">Gungnir</option><option value="Hades">Hades</option><option value="Hyperion">Hyperion</option><option value="Ifrit">Ifrit</option><option value="Ixion">Ixion</option><option value="Jenova">Jenova</option><option value="Kujata">Kujata</option><option value="Lamia">Lamia</option><option value="Leviathan">Leviathan</option><option value="Lich">Lich</option><option value="Louisoix">Louisoix</option><option value="Malboro">Malboro</option><option value="Mandragora">Mandragora</option><option value="Masamune">Masamune</option><option value="Mateus">Mateus</option><option value="Midgardsormr">Midgardsormr</option><option value="Moogle">Moogle</option><option value="Odin">Odin</option><option value="Omega">Omega</option><option value="Pandaemonium">Pandaemonium</option><option value="Phoenix">Phoenix</option><option value="Ragnarok">Ragnarok</option><option value="Ramuh">Ramuh</option><option value="Ridill">Ridill</option><option value="Sargatanas">Sargatanas</option><option value="Shinryu">Shinryu</option><option value="Shiva">Shiva</option><option value="Siren">Siren</option><option value="Spriggan">Spriggan</option><option value="Tiamat">Tiamat</option><option value="Titan">Titan</option><option value="Tonberry">Tonberry</option><option value="Twintania">Twintania</option><option value="Typhon">Typhon</option><option value="Ultima">Ultima</option><option value="Ultros">Ultros</option><option value="Unicorn">Unicorn</option><option value="Valefor">Valefor</option><option value="Yojimbo">Yojimbo</option><option value="Zalera">Zalera</option><option value="Zeromus">Zeromus</option><option value="Zodiark">Zodiark</option></optgroup></select></div><h5 class="heading--side--lead">Primary language</h5><div class="select-pulldown"><label class="control-label" for="lang"></label><select name="community_lang" class="select-pulldown__open"><option value="">Select All</option><option value="ja">Japanese</option><option value="en">English</option><option value="de">German</option><option value="fr">French</option></select></div><h5 class="heading--side--lead">Displaying</h5><div class="select-pulldown"><label class="control-label" for="limit"></label><select name="community_limit" class="select-pulldown__open"><option value="10">10</option><option value="20">20</option><option value="30">30</option></select></div><div class="form__submit form__submit--full"><input type="submit" value="Filter" class="js__bt_communitywall_filter"></div>
+						</div>
+
+
+					</div>
+				</div>
+
+
+				<ul class="side__list__box">
+
+
+					<div class="entry more_"><a href="/lodestone/character/22869886/blog/4942271/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-1eb9c4450ec" class="datetime_dynamic_ymdhm" data-epoch="1642767549">-</span><script>document.getElementById('datetime-1eb9c4450ec').innerHTML = ldst_strftime_dynamic_ymdhm(1642767549);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Yakkuru Imu</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Atomos&nbsp;(Elemental)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Yakkuru Imu (<i class="xiv-lds xiv-lds-home-world"></i>Atomos) posted a new blog entry, "神マクロ."</p></div></div></div></a><a href="/lodestone/character/22869886/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/6522ae817557ddb610a62c3af73aab92_cf768a751b1f5e355c2fd39a9ed91f3ffc0_96x96.jpg?1642766657" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/35811278/blog/4941646/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-5ea3859f149" class="datetime_dynamic_ymdhm" data-epoch="1642767549">-</span><script>document.getElementById('datetime-5ea3859f149').innerHTML = ldst_strftime_dynamic_ymdhm(1642767549);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Malu Design</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Zeromus&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Malu Design (<i class="xiv-lds xiv-lds-home-world"></i>Zeromus) posted a new blog entry, "初めてイベント募集してみた----からのお礼."</p></div></div></div></a><a href="/lodestone/character/35811278/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/3b626fe0af2a05cb78cdf262b187d00d_c76848359d0b4d2f37aefbb9903ed97bfc0_96x96.jpg?1642765110" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/19045024/blog/4942270/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-60bc4e83f32" class="datetime_dynamic_ymdhm" data-epoch="1642767360">-</span><script>document.getElementById('datetime-60bc4e83f32').innerHTML = ldst_strftime_dynamic_ymdhm(1642767360);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Cheesecake Danish</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ifrit&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Cheesecake Danish (<i class="xiv-lds xiv-lds-home-world"></i>Ifrit) posted a new blog entry, "準備不足の特殊FATE、そして、守護天節."</p></div></div></div></a><a href="/lodestone/character/19045024/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/8cf976f182290f8eb112dea3de39f903_f9f796348bc43067c7242ec4551cde69fc0_96x96.jpg?1642764420" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/39466622/blog/4942269/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-1fa8d92792f" class="datetime_dynamic_ymdhm" data-epoch="1642767322">-</span><script>document.getElementById('datetime-1fa8d92792f').innerHTML = ldst_strftime_dynamic_ymdhm(1642767322);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Lilina Shinonome</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ixion&nbsp;(Mana)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Lilina Shinonome (<i class="xiv-lds xiv-lds-home-world"></i>Ixion) posted a new blog entry, "わかってはいるんだけどね・・・."</p></div></div></div></a><a href="/lodestone/character/39466622/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/854d3c933801b806bcc3de04a51267ae_7126768d768f6c6c7fed3eaee98c3a8afc0_96x96.jpg?1642764300" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/23073189/blog/4942266/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-4beb312c6e7" class="datetime_dynamic_ymdhm" data-epoch="1642767082">-</span><script>document.getElementById('datetime-4beb312c6e7').innerHTML = ldst_strftime_dynamic_ymdhm(1642767082);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Pon Rookie</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ifrit&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Pon Rookie (<i class="xiv-lds xiv-lds-home-world"></i>Ifrit) posted a new blog entry, "【ポンデの日常風景】メンバーが釣ってきた「ヌシ」がFCハウスに！の巻."</p></div></div></div></a><a href="/lodestone/character/23073189/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/c858102927ab63ede56d07b2f280210d_f9f796348bc43067c7242ec4551cde69fc0_96x96.jpg?1642764634" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/freecompany/9230127436295964601/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header--common clearfix"><time class="entry__activity__time"><span id="datetime-852b2eca4f3" class="datetime_dynamic_ymdhm" data-epoch="1642767075">-</span><script>document.getElementById('datetime-852b2eca4f3').innerHTML = ldst_strftime_dynamic_ymdhm(1642767075);</script></time></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__fc js__tooltip"data-tooltip="Free Company"></span></div><div class="entry__activity__txt--message"><p>Enjoy Club F (Ixion) has been formed.</p></div></div></div></a><div class="entry__activity__link"><img src="https://img.finalfantasyxiv.com/lds/h/9/_Huf58epDlt9vXiO8IIfPXxtXI.png" width="50" height="50" alt=""></div></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/18833809/blog/4941298/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-735e3e7375b" class="datetime_dynamic_ymdhm" data-epoch="1642767053">-</span><script>document.getElementById('datetime-735e3e7375b').innerHTML = ldst_strftime_dynamic_ymdhm(1642767053);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Killy Toa</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Valefor&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Killy Toa (<i class="xiv-lds xiv-lds-home-world"></i>Valefor) posted a new blog entry, "出来立ておにぎり美味しいです！."</p></div></div></div></a><a href="/lodestone/character/18833809/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/d78c2cdd2b79ef7d6c7af3a6f5daf8ff_485f4777c38002871591fb54f27edc65fc0_96x96.jpg?1642764923" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/community_finder/5ebf60b6d96adea6ec52db90cc06f92ada4245ff/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-fa43587b60f" class="datetime_dynamic_ymdhm" data-epoch="1642766943">-</span><script>document.getElementById('datetime-fa43587b60f').innerHTML = ldst_strftime_dynamic_ymdhm(1642766943);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Mameo Mameo</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Yojimbo&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__community_finder js__tooltip"data-tooltip="Community Finder"></span></div><div class="entry__activity__txt--message"><p>Mameo Mameo (<i class="xiv-lds xiv-lds-home-world"></i>Yojimbo) has started recruitment for the cross-world linkshell "Pandmonium 4sou (Gaia)."</p></div></div></div></a><a href="/lodestone/character/39086707/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/0a5d5e3dc34a27aef68ee11ef010d059_4a92c619bde4f34cfa77e05fef21ad85fc0_96x96.jpg?1642766526" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/8270042/blog/4942263/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-7892637041d" class="datetime_dynamic_ymdhm" data-epoch="1642766873">-</span><script>document.getElementById('datetime-7892637041d').innerHTML = ldst_strftime_dynamic_ymdhm(1642766873);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Kin Giga</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Typhon&nbsp;(Elemental)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Kin Giga (<i class="xiv-lds xiv-lds-home-world"></i>Typhon) posted a new blog entry, "乾杯するぞ〜♪."</p></div></div></div></a><a href="/lodestone/character/8270042/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/3158dad773acbe9d2219b27dd89c6765_32d8c9c7cd5f62d62da2d31b6750a680fc0_96x96.jpg?1642765400" width="40" height="40" alt=""></div></a></div>
+
+
+					<div data-min_id="4838371600" class="entry more_"data-has_next=""><a href="/lodestone/character/32605712/blog/4942261/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-c7464abb287" class="datetime_dynamic_ymdhm" data-epoch="1642766797">-</span><script>document.getElementById('datetime-c7464abb287').innerHTML = ldst_strftime_dynamic_ymdhm(1642766797);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Joe Perrorist</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Yojimbo&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Joe Perrorist (<i class="xiv-lds xiv-lds-home-world"></i>Yojimbo) posted a new blog entry, "【Gaia】零式1-3消化4攻略固定募集【1セット週4活動】."</p></div></div></div></a><a href="/lodestone/character/32605712/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/ded39e003b8fb83c773e61265c1b6d3a_4a92c619bde4f34cfa77e05fef21ad85fc0_96x96.jpg?1642766324" width="40" height="40" alt=""></div></a></div>
+
+
+
+
+				</ul>
+
+
+			</div>
+
+
+
+			<div class="ldst__side__box">
+
+
+
+
+				<div class="heading--side">
+					<h3>Standings</h3>
+					<a href="/lodestone/ranking/" class="heading--side__icon icon-list__side js__tooltip" data-tooltip="See More"></a>
+				</div>
+
+
+				<h4 class="heading--side--sm">The Feast Rankings</h4>
+
+				<a href="/lodestone/ranking/thefeast/result/" class="entry__ranking__thefeast">
+					Pre-season is under way!<br>
+					View results of the previous season
+				</a>
+
+
+
+
+				<h4 class="heading--side--sm">Grand Company Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Luke Breitner</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Fenrir&nbsp;(Gaia)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/9658201/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/bb7875f35a390ed9493dfde91c4d0039_d384cf5ad7db803f29799f36ebbc3eadfc0_96x96.jpg?1642766294" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Kiryuin Satsuki</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/7250925/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/ba64ef52323ad0c23edaa3bafc9f4e82_58a84e851e55175d22158ca97af58a1ffc0_96x96.jpg?1642764909" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Ari Nuovo</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Phoenix&nbsp;(Light)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/19970354/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/1eb1b6c06bbadecb3c0f3b8cbb1b07e0_5047bc596a4bab2dc7f7c120bb22dec5fc0_96x96.jpg?1642766146" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+				</ul>
+
+
+
+				<h4 class="heading--side--sm">Free Company Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">brotherhood</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Moogle&nbsp;(Chaos)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9233364398528115650/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/F00_f4d64b4d75ce7d3be3ba37e24ccc7830_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S01_49d2902352dde56ae3c6423a937ac151_00_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">The Syndicate</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9231394073691073564/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/B08_de875598ba3f5ef9fe02858d29c85455_33_40x40.png" width="40" height="40">
+
+							<img src="https://img2.finalfantasyxiv.com/c/F1e_ed8a164ee0086dc3e36d078e76126110_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S5c_c48179b4e96cff6ed7c51da16ca90c11_04_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">CatOfHeart</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Masamune&nbsp;(Mana)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9236882835737003825/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/B0f_8c3fc97865a1c6bfa360c1bce22b9fa0_c0_40x40.png" width="40" height="40">
+
+							<img src="https://img2.finalfantasyxiv.com/c/F04_1223707ec2cfc1bde4ba8f0f85a74b24_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S33_f0483d3975a483769f674866ff99675e_01_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+				</ul>
+
+
+
+				<h4 class="heading--side--sm">Frontline Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Pharis Bloodborne</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ragnarok&nbsp;(Chaos)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/7338237/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/553c62b150030202afb4206e6f758b91_40d57ba713628f3f1ef5ef204b6d76d2fc0_96x96.jpg?1642764063" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Ni Xi</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Malboro&nbsp;(Crystal)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/34789289/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/356072546b70540163fcdc5bf3f1a6f3_2e97c13fdd593d15d543093f8a37b6f0fc0_96x96.jpg?1642766469" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Blueberry Lollipop</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/39019280/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/2be5c15e35dbd1670f814874fff1234b_58a84e851e55175d22158ca97af58a1ffc0_96x96.jpg?1642764072" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Jo Se</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Sargatanas&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/36466361/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/c9e98a67d1423c12fa7b4c38a41e80e0_ba22853447012a24cee115315d6a5bebfc0_96x96.jpg?1642767272" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Kayeson Mon&#39;roux</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Leviathan&nbsp;(Primal)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/36261740/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/f44e37565c9e753a163ffc1a0d5105ea_a91aae52cff9ef65932db06b150ffd47fc0_96x96.jpg?1642766011" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+				</ul>
+
+
+			</div>
+
+
+
+
+
+
+
+
+
+
+		</div>
+
+	</div>
+
+</div>
+
+
+
+<div id="link_spsite" class="link_sp-site"><a href="javascript:void(0)">Mobile Version</a><br></div><footer class="l__footer l__footer__eu"><div class="page-top"><span class="page-top__btn"></span></div><div class="l__footer__inner"><div class="l__footer__logo"><img src="https://img.finalfantasyxiv.com/lds/h/L/EbtcXqPUGzsVYdi23FpUR25oH4.png" width="320" height="32" alt=""></div><p class="l__footer__officiel">Official Information</p><ul class="l__footer__sns"><li><a href="https://www.facebook.com/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-facebook xiv-lds-3x"></i><span>Facebook</span></a></li><li class="l__footer__sns--twitter"><a href="https://twitter.com/ff_xiv_en" target="_blank"><i class="xiv-lds xiv-lds-twitter xiv-lds-3x"></i>Twitter</a> / <a href="https://twitter.com/FFXIV_NEWS_EN" target="_blank">Twitter News</a></li><li><a href="http://www.youtube.com/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-youtube xiv-lds-3x"></i><span>Official Channel</span></a></li><li><a href="https://www.instagram.com/ffxiv/" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-instagram xiv-lds-3x"></i><span>Instagram</span></a></li><li><a href="https://www.twitch.tv/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-twitch xiv-lds-3x"></i><span>Twitch</span></a></li></ul><ul class="l__footer__link-list"><li class="link_license" id="link_license"><a href="/license/" target="_blank">License</a></li><li><a href="https://support.eu.square-enix.com/rule.php?id=5383&la=2" target="_blank">Rules & Policies</a></li><li><a href="https://square-enix-games.com/en_GB/documents/privacy" target="_blank">Privacy Policy</a></li><li><a href="https://square-enix-games.com/en_GB/documents/cookies" target="_blank">Cookie Policy</a></li></ul></div><div class="l__footer__legal-area"><div class="l__footer__legal-area__inner clearfix"><div class="l__footer__legal-area__box"><ul class="l__footer__legal-area__bnr-list"><li><a href="http://www.pegi.info" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/h/8/bLhWLeqRDavUCuBhK8X0yB9bKA.png" width="41" height="50" alt="PEGI"></a></li><li><img src="https://img.finalfantasyxiv.com/lds/h/D/egrXwtjrQC8nFGhA1rWb0PO8R0.png" width="245" height="39" alt="PlayStation PS5 PS4"></li><li><img src="https://img.finalfantasyxiv.com/lds/h/E/38lyWv84H59UEwldgCOGU2B9dM.png" width="33" height="39" alt="PC"></li><li><img src="https://img.finalfantasyxiv.com/lds/h/v/hyXqlwktN4v0EssRTzkbMf_7OQ.png" width="30" height="39" alt="Mac"></li><li class="last"><img src="https://img.finalfantasyxiv.com/lds/h/U/15QxPO___EcPlhMI9ydNRRxEY8.png" width="90" height="39" alt="STEAM"></li></ul><p class="l__footer__legal-area__text">“<i class="ps"></i>”, “PlayStation”, “<i class="ps5"></i>” and “<i class="ps4"></i>” are registered trademarks or trademarks of Sony Interactive Entertainment Inc.<br />Mac is a trademark of Apple Inc.<br />©2021 Valve Corporation. Steam and the Steam logo are trademarks and/or registered trademarks of Valve Corporation in the U.S. and/or other countries.</p></div><div class="l__footer__legal-area__box"><p class="l__footer__legal-area__copyright">© 2010 - 2022 <a href="https://square-enix-games.com/en_GB" target="_blank">SQUARE ENIX</a> CO., LTD. All Rights Reserved.<br>ENDWALKER, SHADOWBRINGERS, STORMBLOOD, HEAVENSWARD and A REALM REBORN are registered trademarks or trademarks of Square Enix Co., Ltd.<br />FINAL FANTASY, FINAL FANTASY XIV, FFXIV, SQUARE ENIX and the SQUARE ENIX logo are registered trademarks or trademarks of Square Enix Holdings Co., Ltd.<br>LOGO ILLUSTRATION: © 2010, 2014, 2016, 2018, 2021 YOSHITAKA AMANO</p></div></div></div></footer>
+
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-43364669-4"></script>
+<script>
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+
+	(function() {
+		var gtag_config = {
+			'link_attribution': true,
+			'custom_map': {
+				'dimension1': 'login',
+				'dimension2': 'theme',
+				'dimension3': 'mychara',
+				'dimension4': 'character_link'
+			},
+			'login': 'notloginuser',
+			'theme':  'white',
+		};
+
+
+		gtag('js', new Date());
+
+		gtag('config', 'UA-43364669-4', gtag_config);
+		gtag('config', 'UA-43364669-1', gtag_config);
+	})();
+</script>
+
+
+
+
+<script src="https://img.finalfantasyxiv.com/lds/pc/en-gb/js/i18n.js?1642399092"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/i/2ur_0e4qXk_NwNv0bGjrUHThCM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/g/uQNBgvCaabd4gw5kMpaT-psp1Q.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/b/RKD_bGx738E81TyiPQN4kGf-_Y.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/Z/wqo4GxX1wALdnxx6xOv38NxFVY.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/e/TSPHxkEhdcyaPMm0rpoBtk1dZA.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/P/O9-IKBqOphhkhVvm2QPrR9x5p4.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/9/TTeYt1mN0BF3R1Av3fWlknchv4.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/8/b_tPmOnEw1tyr2dp2InkGxUlMA.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/Y/6WaukM6m3WFE2JXrCEb6tsknik.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/E/ImNUSWkI-O9dQP5ADa41RiGxGY.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/t/kQLYFR8rOESAOiyT9o2PsRnLq0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/C/q1cplyit_St5sY1BUgBKFuLapM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/s/Gt4XmT3a3nu52yKZPoVWcvrfFM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/A/LATlIIBarKmGFTTVid87k_GPFg.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/W/r-0ziwRwdsVj1lEyFHfmVyFgKw.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/piXyeCeUEtNAzCIq6jXoqNimzE.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/t/85HyWVlETnECMXo9l40HahjdO0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/OIfkF0BnyASNQ0RswButWbIKCU.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/U/jhEwPt7MvJy47-ExjjZ3lHW3qI.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/0/f52zA7ACWvjEMB1oWe8kfyGWH0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/l/-_ePiHXNE_1t8LnRcmRAbhRME8.js"></script>
+<script src="https://www.youtube.com/iframe_api"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/P/MYGDtxveSuUwuhprm8oj1Hhuq8.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/it7tc9wvjlJJstEQUNjiModhdM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/n/HMQm8_JEoqrSmuv5RmmKgTldGc.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/B/ElvNJhxzt4ULBYHMPrt3JiAKGU.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/R/ziSaNz9uSOY4xecH-XUKggfdeU.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/d/UfPsCOe_Nl7ytqem4KWdsftkY0.js"></script>
+
+
+<div id="dialog_bg" style="opacity:0; visibility: hidden;"></div>
+<!-- dialog -->
+<div name="ldstDialog" class="overlay__area js__overlay" style="opacity:0; visibility: hidden; top: 0px">
+	<p class="overlay__text--icon"></p>
+
+	<div class="outbound_consent hide">
+		<input type="checkbox" name="outbound_consent" value="1" id="outbound_consent" class="form__checkbox">
+		<label for="outbound_consent" class="form__checkbox__label form__outbound">
+			Do not show this message again.
+		</label>
+	</div>
+
+	<!-- SIMPLE DIALOG -->
+	<a href="javascript:void(0);" class="js__dialog_btn btn__color--radius js__overlay_ok">Confirm</a>
+	<!-- //SIMPLE DIALOG -->
+	<!-- CONFIRM DIALOG -->
+	<ul class="js__dialog_btn overlay__btn js__overlay_btn">
+		<li><a href="javascript:void(0);" class="js__overlay_yes">Yes</a></li>
+		<li><a href="javascript:void(0);" class="js__overlay_no">No</a></li>
+	</ul>
+	<!-- //CONFIRM DIALOG -->
+</div>
+<!-- //dialog -->
+
+
+
+
+</body>
+</html>

--- a/src/test/resources/data/lodestone/Character-33000061.html
+++ b/src/test/resources/data/lodestone/Character-33000061.html
@@ -1,0 +1,1322 @@
+<!DOCTYPE html>
+<html lang="en-gb" class="en-gb" xmlns:og="http://ogp.me/ns#" xmlns:fb="http://www.facebook.com/2008/fbml">
+<head><meta charset="utf-8">
+
+	<!-- Google Tag Manager -->
+	<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+			new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+		j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+	})(window,document,'script','digitalData','GTM-P37XSWJ');</script>
+	<!-- End Google Tag Manager -->
+
+	<title>Ivis Castalia | FINAL FANTASY XIV, The Lodestone</title>
+	<meta name="description" content="Character profile for Ivis Castalia.">
+	<meta name="keywords" content="FF14,FFXIV,Final Fantasy XIV,Final Fantasy 14,Lodestone,players' site,community site,A Realm Reborn,Heavensward,Stormblood,Shadowbringers,Endwalker,MMO">
+	<meta name="author" content="SQUARE ENIX Ltd.">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="format-detection" content="telephone=no">
+
+	<link rel="shortcut icon" type="image/vnd.microsoft.icon" href="https://img.finalfantasyxiv.com/lds/pc/global/images/favicon.ico?1490749553">
+	<link rel="apple-touch-icon-precomposed" href="https://img.finalfantasyxiv.com/lds/h/0/U2uGfVX4GdZgU1jASO0m9h_xLg.png">
+	<meta name="msapplication-TileImage" content="https://img.finalfantasyxiv.com/lds/h/0/U2uGfVX4GdZgU1jASO0m9h_xLg.png">
+
+	<meta name="msapplication-TileColor" content="#000000">
+	<link rel="alternate" hreflang="ja" href="https://jp.finalfantasyxiv.com/lodestone/character/33000061">
+	<link rel="alternate" hreflang="en-us" href="https://na.finalfantasyxiv.com/lodestone/character/33000061">
+	<link rel="alternate" hreflang="fr" href="https://fr.finalfantasyxiv.com/lodestone/character/33000061">
+	<link rel="alternate" hreflang="de" href="https://de.finalfantasyxiv.com/lodestone/character/33000061">
+
+
+	<meta name="google-site-verification" content="WwpBRGfcVWgP_LxTs8PHc6EcDM8eCt8Zqck1MAnVmZM">
+
+
+
+
+	<!--[if lt IE 9]>
+	<script src="https://img.finalfantasyxiv.com/lds/h/I/SMlNRnAvuilc1lYKBpzKWpmADs.js"></script>
+
+	<![endif]-->
+	<!-- ** CSS ** -->
+	<link href="https://img.finalfantasyxiv.com/lds/h/M/0kxkkawCCBg1ArBrU_c1cydINM.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/-/tUrZCLFtMgzaHil2OXxbmdw2a0.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/l/6D7j33OWZQd8eVk8IKWT15deH8.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/j/JgAulXN0McN_xRNcKLLbnNh4fs.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/F/wZHqGlYFe-0or10VJJtARsKyko.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/a/bmAvctt6TxsMwvFeI4NiKcWnZM.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/Q/mAASajjDE39sDOGkuOPDZPBt0s.css" rel="stylesheet">
+	<link href="https://img.finalfantasyxiv.com/lds/h/w/YgRYdK0dq3N9UCU6nR-7J5PftA.css" rel="stylesheet">
+
+	<link href="https://img.finalfantasyxiv.com/lds/h/b/tInX1HM2lXTimf4ts8i-7wWr1Y.css" rel="stylesheet">
+
+	<link href="https://img.finalfantasyxiv.com/lds/h/w/cuKVxIZUo5Tf3xQ8a9_mn8jZDU.css" rel="stylesheet"
+		  class="sys_theme_css"
+
+		  data-theme_white="https://img.finalfantasyxiv.com/lds/h/w/cuKVxIZUo5Tf3xQ8a9_mn8jZDU.css"
+
+		  data-theme_black="https://img.finalfantasyxiv.com/lds/h/o/q3zLnccpt9t--buuJJqeuTpzOY.css"
+
+	>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<!-- ogp -->
+	<meta property="fb:app_id" content="1400886233468625">
+	<meta property="og:type" content="website">
+	<meta property="og:description" content="Character profile for Ivis Castalia.">
+	<meta property="og:title" content="Ivis Castalia | FINAL FANTASY XIV, The Lodestone">
+	<meta property="og:url" content="https://eu.finalfantasyxiv.com/lodestone/character/33000061">
+	<meta property="og:site_name" content="FINAL FANTASY XIV, The Lodestone">
+	<meta property="og:locale" content="en_GB">
+
+	<meta property="og:image" content="https://img.finalfantasyxiv.com/lds/h/I/cy_FoBlOdFg3kBAQdaAxT19pTw.png">
+
+
+
+	<meta property="fb:pages" content="116214575870">
+
+
+	<meta name="twitter:card" content="summary_large_image">
+
+	<meta name="twitter:site" content="@ff_xiv_en">
+
+
+
+
+	<script>
+		var base_domain = 'finalfantasyxiv.com';
+		var ldst_subdomain = 'eu';
+		var strftime_fmt = {
+			'dateHHMM_now': 'Today %H:%M',
+			'dateYMDHMS': '%d/%m/%Y %H:%M:%S',
+			'dateYMDHM': '%d/%m/%Y %H:%M',
+			'dateYMDHM_jp': '%Y/%m/%d %H:%M',
+			'dateHM': '%H:%M',
+			'dateYMDH': '%d/%m/%Y %H',
+			'dateYMD': '%d/%m/%Y',
+			'dateEternal': '%d.%m.%Y',
+			'dateYMDW': '%d/%m/%Y (%a)',
+			'dateHM': '%H:%M',
+			'week.0': 'Sun.',
+			'week.1': 'Mon.',
+			'week.2': 'Tue.',
+			'week.3': 'Wed.',
+			'week.4': 'Thu.',
+			'week.5': 'Fri.',
+			'week.6': 'Sat.'
+		};
+		var base_uri   = '/lodestone/';
+		var api_uri    = '/lodestone/api/';
+		var static_uri = 'https://img.finalfantasyxiv.com/lds/';
+		var subdomain  = 'eu';
+		var csrf_token = 'b726b2475aab6e2b29c16ddcf48f50e5e7d76211';
+		var cis_origin = 'https://secure.square\u002denix.com';
+		var ldst_max_image_size = 31457280;
+		var eorzeadb = {
+			cdn_prefix: 'https://img.finalfantasyxiv.com/lds/',
+			version: '1641278251',
+			version_js_uri:  'https://img.finalfantasyxiv.com/lds/pc/global/js/eorzeadb/version.js',
+			dynamic_tooltip: false
+		};
+		var cookie_suffix = '';
+		var ldst_is_loggedin = false;
+		var show_achievement = false;
+	</script>
+	<script src="https://img.finalfantasyxiv.com/lds/h/A/PknAmzDJUZCNhTGtSGGMIGi5k4.js"></script>
+	<script src="https://img.finalfantasyxiv.com/lds/h/H/hBuD3_ZXTqwHX64YYCchtvgGSs.js"></script>
+
+
+
+
+
+
+
+
+
+</head>
+<body id="community" class=" lang_eu">
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P37XSWJ"
+				  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+
+
+
+<div class="brand"><div class="brand__section">
+	<div class="brand__logo">
+		<a href="
+				https://square-enix-games.com/en_GB
+			" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/h/L/cxcD5kjeM52JRVwrrzIF4dZNe0.png" width="130" height="14" alt="SQUARE ENIX">
+		</a>
+	</div>
+
+
+	<div class="brand__search">
+		<form action="/lodestone/community/search/" class="brand__search__form">
+			<div class="brand__search__focus_bg"></div>
+			<div class="brand__search__base_bg"></div>
+			<input type="text" id="txt_search" class="brand__search--text" name="q" placeholder="Search">
+			<input type="submit" id="bt_search" class="brand__search--btn" value="">
+		</form>
+	</div>
+
+
+
+	<div class="brand__theme sys_theme_switcher">
+		<a href="javascript:void(0);"><i class="brand__theme--white sys_theme active js__tooltip" data-tooltip="Theme (Black)" data-theme="white"></i></a>
+		<a href="javascript:void(0);"><i class="brand__theme--black sys_theme js__tooltip" data-tooltip="Theme (White)" data-theme="black"></i></a>
+	</div>
+
+
+	<div class="brand__lang dropdown_trigger_box">
+		<a href="javascript:void(0);" class="brand__lang__btn brand__lang__en-gb dropdown_trigger">English</a>
+		<ul class="brand__lang__select dropdown">
+
+			<li><a href="https://jp.finalfantasyxiv.com/lodestone/character/33000061" class="brand__lang__jp">日本語</a></li>
+
+			<li><a href="https://na.finalfantasyxiv.com/lodestone/character/33000061" class="brand__lang__na">English</a></li>
+
+			<li><a href="https://eu.finalfantasyxiv.com/lodestone/character/33000061" class="brand__lang__eu">English</a></li>
+
+			<li><a href="https://fr.finalfantasyxiv.com/lodestone/character/33000061" class="brand__lang__fr">Français</a></li>
+
+			<li><a href="https://de.finalfantasyxiv.com/lodestone/character/33000061" class="brand__lang__de">Deutsch</a></li>
+
+		</ul>
+	</div>
+
+
+
+	<div class="l__cross_menu eu">
+		<a href="javascript:void(null)" class="ffxiv_pr_cross_menu_button_eu"></a>
+		<script>
+			var ffxiv_pr_cross_menu = {
+				uri_js: '/cross_menu/uri.js'
+			};
+		</script>
+		<script src="https://img.finalfantasyxiv.com/lds/promo/pc/global/menu/loader.js"></script>
+	</div>
+
+</div></div>
+
+
+
+
+<header class="l__header">
+	<div class="l__header__inner l__header__bg_image" style="background-image: url(https://img.finalfantasyxiv.com/lds/banner/1074/headerImage_6_0_eu.jpg);">
+		<a href="/lodestone/" class="l__header__link_top"></a>
+
+
+		<a href="/lodestone/topics/detail/66a742165e9415790247c1a1f7d909abf5becb5c/?utm_source=lodestone&amp;utm_medium=pc_header&amp;utm_campaign=eu_6_0patch" class="l__header__link_management"></a>
+
+
+		<div class="l__header__login clearfix"><a href="/lodestone/account/login/" class="l__header__login__btn">
+			<img src="https://img.finalfantasyxiv.com/lds/h/z/6PLTZ82M99GJ7tKOee1RSwvNrQ.png" width="40" height="40" alt="" class="l__header__login__chara_silhouette">
+			<div class="l__header__login__txt">
+				<p>View Your Character Profile</p>
+				<div>Log In</div>
+			</div>
+		</a></div>
+
+
+	</div>
+</header>
+
+
+
+
+
+
+
+
+
+
+<div class="global-nav">
+	<nav class="main-nav eu">
+		<ul class="main-nav__area main-nav__area__community clearfix ">
+			<li class="main-nav__news main-nav__item">
+				<a href="/lodestone/news/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_news-top');"><span>News</span></a>
+				<nav class="sub-nav">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__news">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__news__icon">
+									<li>
+										<a href="/lodestone/news/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_top');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/8/2GwuzUcvqLa-hgQeLUyd8xarI8.png" width="32" height="32" alt="News">
+											News
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/topics/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_topics');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/5/67ZyAIzQUaYoWBmyvFwNvGmCnQ.png" width="32" height="32" alt="Topics">
+											Topics
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/1" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_notices');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/-/Y5JdwnEWYfyO7OlH27eKIm91Ok.png" width="32" height="32" alt="Notices">
+											Notices
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/2" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_maintenance');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/s/-JfULvMAf26L7AaU1OGaGYwanI.png" width="32" height="32" alt="Maintenance">
+											Maintenance
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/3" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_updates');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/p/HPudyOQcwdv97RBwj3FQC552ps.png" width="32" height="32" alt="Updates">
+											Updates
+										</div></a>
+									</li>
+									<li>
+										<a href="/lodestone/news/category/4" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_Status');"><div>
+											<img src="https://img.finalfantasyxiv.com/lds/h/S/-IC2xIQhTl2ymYW7deE1fOII04.png" width="32" height="32" alt="Status">
+											Status
+										</div></a>
+									</li>
+								</ul>
+								<ul class="sub-nav__news__text">
+									<li><a href="/lodestone/special/patchnote_log/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_patch-notes_special-sites');"><div>
+										Patch Notes and Special Sites
+										<span class="update">
+											Updated <span id="datetime-b1a209eeb97">-</span><script>document.getElementById('datetime-b1a209eeb97').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</div></a></li>
+									<li><a href="/lodestone/special/update_log/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_lodestone-update-notes');"><div>
+										<span class="sub_text">Official Community Site</span>
+										The Lodestone Update Notes
+										<span class="update">
+											Updated <span id="datetime-f7ee8496241">-</span><script>document.getElementById('datetime-f7ee8496241').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</div></a></li>
+									<li><a href="/lodestone/worldstatus/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_news_server-status');"><div>
+										Server Status
+									</div></a></li>
+								</ul>
+							</div>
+						</div>
+
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__promotion main-nav__item">
+				<a href="/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_begin-ff14-top');"><span>Getting Started</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__promotion">
+							<div class="sub-nav__list__inner">
+								<div class="sub-nav__promotion__inner">
+									<div class="sub-nav__promotion__link">
+										<div class="sub-nav__promotion__top">
+											<a href="/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_pr');"><img src="https://img.finalfantasyxiv.com/lds/h/P/ciPXy1S4-ssQuLQJvEF4JWVm5Q.jpg" width="632" height="140" alt="FINAL FANTASY XIV: A Realm Reborn"></a>
+										</div>
+										<ul class="sub-nav__promotion__page">
+											<li><a href="/benchmark/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_benchmark');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/S/2_8ofX4E90a7pS-p0mjFK_tc_U.png" width="64" height="40" alt="Benchmark">
+												<span>Benchmark</span>
+											</a></li>
+											<li><a href="
+
+													http://freetrial.finalfantasyxiv.com/
+												" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_freetrial');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/c/tWvZpXDc_g6yQd5YKK2k5jhuns.png" width="64" height="40" alt="Free Trial">
+												<span>Free Trial</span>
+											</a></li>
+											<li><a href="/product/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_product');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/m/NCNLGrn3U9M85ky-NscraujvN8.png" width="64" height="40" alt="Product">
+												<span>Product</span>
+											</a></li>
+											<li><a href="/winning/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_awards');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/j/udWU20sWmhYoEsQ_FtrAzVwJ3Q.png" width="64" height="40" alt="Awards and Nominations">
+												<span>Awards and Nominations</span>
+											</a></li>
+										</ul>
+									</div>
+									<div class="sub-nav__promotion__patch_site">
+										<a href="/endwalker/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_begin-ff14_latest-expansion');"><span>
+											<img src="https://img.finalfantasyxiv.com/lds/h/f/sLzgsq-NNdSMdqLt6Mby4oROC0.png" width="296" height="232" alt="FINAL FANTASY XIV: Endwalker Special Site">
+										</span></a>
+									</div>
+								</div>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+			</li>
+			<li class="main-nav__playguide main-nav__item">
+				<a href="/lodestone/playguide/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_playguide-top');"><span>Play Guide</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__playguide">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__playguide__list">
+									<li><a href="/lodestone/playguide/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_playguide-top');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/P/Lfl3LVb9KMPa5Ye8yxftZkelbc.png" width="40" height="40" alt="Play Guide<br />Top">
+										<span>Play Guide<br />Top</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#game_playguide" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_game-playguide');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/q/qy4dUGMNkjoyVqPweYMIpOApik.png" width="40" height="40" alt="Gameplay Guide and<br />Beginners' Guide">
+										<span>Gameplay Guide and<br />Beginners' Guide</span>
+										<span class="update">
+											Updated <span id="datetime-a508d10d2db">-</span><script>document.getElementById('datetime-a508d10d2db').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/db/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_databese');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/N/OYPWhQVCkovUbVcMMck0O4HABU.png" width="40" height="40" alt="Eorzea Database">
+										<span>Eorzea Database</span>
+										<span class="update">
+											Updated <span id="datetime-b16eda8bb21">-</span><script>document.getElementById('datetime-b16eda8bb21').innerHTML = ldst_strftime(1641283200, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#content_guide" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_contents-guide');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/W/wlHP1NMpdQHcPKUG-swlv71fhE.png" width="40" height="40" alt="Game Features">
+										<span>Game Features</span>
+										<span class="update">
+											Updated <span id="datetime-9a99e752a88">-</span><script>document.getElementById('datetime-9a99e752a88').innerHTML = ldst_strftime(1638518400, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#side_storyes" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_side-story');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/Z/1QWgBsVU7ZboWyMZlRjCQcDRJg.png" width="40" height="40" alt="Side Stories<br />and More">
+										<span>Side Stories<br />and More</span>
+										<span class="update">
+											Updated <span id="datetime-f96a082f629">-</span><script>document.getElementById('datetime-f96a082f629').innerHTML = ldst_strftime(1632470400, 'YMD');</script>
+										</span>
+									</a></li>
+									<li><a href="/lodestone/playguide/#option_service" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_playguide_option-service');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/4fXwcEoJzDEmFRt-tD7PeeKvjE.png" width="40" height="40" alt="Additional Services">
+										<span>Additional Services</span>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__community main-nav__item">
+				<a href="/lodestone/community/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_community-top');"><span>Community</span></a>
+				<nav class="sub-nav">
+					<div class="sub-nav__area">
+
+
+						<div class="sub-nav__list sub-nav__community">
+							<div class="sub-nav__list__inner sub-nav__community__flex">
+								<div class="sub-nav__community__link">
+									<div class="sub-nav__community__top">
+										<div class="sub-nav__community__top__wrapper">
+											<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/q/GiEpnP3oCXluFjrlPlM-mgIbS8.png" width="16" height="16" alt="Community">Community</h2>
+											<ul class="sub-nav__community__list">
+												<li><a href="/lodestone/community/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_community-top');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/i/Sa5YF2-VFf4IJ1cjjFAbPf4GWg.png" width="40" height="40" alt="Community Wall">
+													<span>Community Wall</span>
+												</a></li>
+												<li><a href="/lodestone/blog/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_blog');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/h/6gPbLbzUQ_omC_mdXFUA3zPy7I.png" width="40" height="40" alt="Blog">
+													<span>Blog</span>
+												</a></li>
+											</ul>
+										</div>
+										<div class="sub-nav__community__top__wrapper">
+											<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/d/in_Sbc6SzxLU--Npa7URI-_kdg.png" width="16" height="16" alt="Member Recruitment">Member Recruitment</h2>
+											<ul class="sub-nav__community__list">
+												<li><a href="/lodestone/community_finder/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_community-finder');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/V/kHxwEjpY-Fme83ta8VIfi1kyLU.png" width="40" height="40" alt="Community Finder">
+													<span>Community Finder</span>
+												</a></li>
+												<li><a href="/lodestone/event/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_event-party');">
+													<img src="https://img.finalfantasyxiv.com/lds/h/0/k5jD6-BJZHwKA2CtbNcDYZR6oY.png" width="40" height="40" alt="Event & Party Recruitment">
+													<span>Event & Party Recruitment</span>
+												</a></li>
+											</ul>
+										</div>
+									</div>
+									<div class="sub-nav__community__search">
+										<h2 class="sub-nav__community__title"><img src="https://img.finalfantasyxiv.com/lds/h/X/uQVT3DEl1xlFWHu3UZU4-RBtVk.png" width="16" height="16" alt="Search">Search</h2>
+										<ul class="sub-nav__community__list sub-nav__community__search__list">
+											<li><a href="/lodestone/character/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_chara-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/5/YcEF3K-5SgqU0BxZtT0D1Zsa2A.png" width="40" height="40" alt="Character Search">
+												<span>Character Search</span>
+											</a></li>
+											<li><a href="/lodestone/linkshell/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_ls-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/b/SPCgcBAk4HvMngGzk6H4MfSINg.png" width="40" height="40" alt="Linkshell Search">
+												<span>Linkshell Search</span>
+											</a></li>
+											<li><a href="/lodestone/crossworld_linkshell/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_cwls-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/L/NUGcPcy-C8jvx6oKgEXgwJ1ePE.png" width="40" height="40" alt="CWLS Search ">
+												<span>CWLS Search </span>
+											</a></li>
+											<li><a href="/lodestone/freecompany/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_fc-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/q/GJ-lsgAtsCCDwCm9te3a5sCjpU.png" width="40" height="40" alt="Free Company Search">
+												<span>Free Company Search</span>
+											</a></li>
+											<li><a href="/lodestone/pvpteam/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_pvp-team-search');">
+												<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="PvP Team Search">
+												<span>PvP Team Search</span>
+											</a></li>
+										</ul>
+									</div>
+								</div>
+								<div class="sub-nav__community__side">
+									<div class="sub-nav__community__forum">
+										<ul class="sub-nav__community__forum__list">
+											<li><a href="https://forum.square-enix.com/ffxiv/forum.php" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum');">
+												<div class="forum">
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/r/maZ-sHaqn4PMFANUlbH4GzztFM.png" width="40" height="40" alt="Forums">
+													</i><span>Forums</span>
+												</div>
+											</a></li>
+											<li><a href="https://forum.square-enix.com/ffxiv/search.php?do=getdaily_ll&contenttype=vBForum_Post" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum-new-posts');">
+												<div>
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+													</i><span>New Posts</span>
+												</div>
+											</a></li>
+											<li><a href="
+
+														https://forum.square-enix.com/ffxiv/search.php?do=process&search_type=1&contenttypeid=1&devtrack=1&starteronly=0&showposts=1&childforums=1&forumchoice[]=619
+													" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_forum-dev-tracker');">
+												<div>
+													<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+													</i><span>Dev Tracker</span>
+												</div>
+											</a></li>
+										</ul>
+									</div>
+									<ul class="sub-nav__community__fankit">
+										<li><a href="/lodestone/special/fankit/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_community_fankit');">
+											<div>
+												<span>Fan Kit</span>
+												<span class="update">
+													Updated <span id="datetime-37062020f66">-</span><script>document.getElementById('datetime-37062020f66').innerHTML = ldst_strftime(1640332800, 'YMD');</script>
+												</span>
+											</div>
+										</a></li>
+									</ul>
+								</div>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__ranking main-nav__item">
+				<a href="/lodestone/ranking/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_ranking-top');"><span>Standings</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__ranking">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__ranking__list">
+									<li><a href="/lodestone/ranking/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_ranking-top');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/E/NtymEFiUJfAh25ffTrADsVFkLQ.png" width="40" height="40" alt="Standings Top">
+										<span>Standings Top</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/thefeast/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_feast');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="The Feast Rankings">
+										<span>The Feast Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/deepdungeon2/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_deepdungeon2');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/_/qP22LgUoAFKDTRayb_TEYu6d7g.png" width="40" height="40" alt="Heaven-on-High Rankings">
+										<span>Heaven-on-High Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/deepdungeon/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_deepdungeon');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/p/op9iPrlMmYgTK3Q6NQKifyQOGA.png" width="40" height="40" alt="Palace of the Dead Rankings">
+										<span>Palace of the Dead Rankings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/frontline/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_frontline');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/K/vZf_pjL1HRJCDF9mxKFKb8iISc.png" width="40" height="40" alt="Frontline Standings">
+										<span>Frontline Standings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/gc/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_gc');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/o/uRmujlTx4X_5c6wETNxssK1d_4.png" width="40" height="40" alt="Grand Company Standings">
+										<span>Grand Company Standings</span>
+									</a></li>
+									<li><a href="/lodestone/ranking/fc/weekly/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_ranking_fc');">
+										<img src="https://img.finalfantasyxiv.com/lds/h/q/GJ-lsgAtsCCDwCm9te3a5sCjpU.png" width="40" height="40" alt="Free Company Standings">
+										<span>Free Company Standings</span>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+			<li class="main-nav__help main-nav__item">
+				<a href="/lodestone/help/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_main-menu', 'eu_help-support-top');"><span>Help & Support</span></a>
+				<nav class="sub-nav ">
+					<div class="sub-nav__area ">
+
+
+						<div class="sub-nav__list sub-nav__help">
+							<div class="sub-nav__list__inner">
+								<ul class="sub-nav__help__list">
+									<li><a href="/lodestone/help/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_help-support-top');">
+										<span>Help & Support</span>
+									</a></li>
+									<li><a href="/lodestone/help/about_the_lodestone/" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_about-lodestone');">
+										<span>About the Lodestone</span>
+									</a></li>
+									<li><a href="
+
+											https://support.eu.square-enix.com/faq.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_faq');">
+										<span>FAQ</span>
+									</a></li>
+									<li><a href="
+
+											https://eu.square-enix.com/en/seaccount/
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_sqex-account');">
+										<span>Square Enix Account Information</span>
+									</a></li>
+								</ul>
+								<ul class="sub-nav__help__other">
+									<li><a href="
+
+											https://support.eu.square-enix.com/rule.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_rule-policies');">
+										<div>
+											<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+											</i><span>Rules & Policies</span>
+										</div>
+									</a></li>
+									<li><a href="
+
+											https://support.eu.square-enix.com/main.php?id=5383&la=2
+										" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_customer-service');">
+										<div>
+											<i><img src="https://img.finalfantasyxiv.com/lds/h/p/hIKumMfCocoSfxWeUUUIL78Jhg.png" width="16" height="16" alt="">
+											</i><span>Customer Service</span>
+										</div>
+									</a></li>
+									<li><a href="https://sqex.to/Msp" target="_blank" onClick="ldst_ga('send', 'event', 'lodestone_lo', 'pc_sub-menu', 'eu_help-support_mogstation');">
+										<div>
+											<i class="ic_mogst"><img src="https://img.finalfantasyxiv.com/lds/h/S/6IKp0hN6xQqTYPgnPIsd2fjzSI.png" width="32" height="32" alt="">
+											</i><span>Mog Station</span>
+										</div>
+									</a></li>
+								</ul>
+							</div>
+						</div>
+
+					</div>
+				</nav>
+
+			</li>
+		</ul>
+	</nav>
+</div>
+
+
+
+
+<div class="ldst__bg">
+
+	<div id="breadcrumb">
+		<ul itemscope itemscope itemtype="https://schema.org/BreadcrumbList" class="clearfix">
+			<li class="breadcrumb__home" itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/" itemprop="item"><span itemprop="name">HOME</span></a>
+				<meta itemprop="position" content="1" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/community/" itemprop="item" class="breadcrumb__link"><span itemprop="name">Community</span></a>
+				<meta itemprop="position" content="2" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<a href="/lodestone/character/" itemprop="item" class="breadcrumb__link"><span itemprop="name">Character</span></a>
+				<meta itemprop="position" content="3" />
+			</li>
+
+
+
+
+
+			<li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+				<span itemprop="name">Ivis Castalia</span>
+				<meta itemprop="position" content="4" />
+			</li>
+
+
+		</ul>
+	</div>
+
+
+	<h1 class="heading__title">Character</h1>
+
+
+
+	<nav class="btn__corner_block">
+		<ul class="btn__corner_block--3">
+
+			<li>
+				<a href="/lodestone/character/33000061/" class="btn__menu btn__menu--active">Profile</a>
+			</li>
+			<li>
+				<a href="/lodestone/character/33000061/blog/" class="btn__menu">Blog</a>
+			</li>
+			<li>
+				<a href="/lodestone/character/33000061/event/" class="btn__menu">Events</a>
+			</li>
+
+		</ul>
+	</nav>
+
+
+
+	<div class="ldst__contents clearfix">
+
+		<div class="ldst__main">
+
+
+
+			<div id="character" class="ldst__window">
+				<h2 class="heading--lg">Character</h2>
+
+
+
+				<div class="frame__chara js__toggle_wrapper">
+					<a href="/lodestone/character/33000061/" class="frame__chara__link">
+						<div class="frame__chara__face">
+							<img src="https://img2.finalfantasyxiv.com/f/c89729f713c11518b5f0b660bdd42b41_96ab1df8877c1f8ba6a89a39cccfd437fc0_96x96.jpg?1642765243" width="40" height="40" alt="">
+						</div>
+						<div class="frame__chara__box">
+
+							<p class="frame__chara__name">Ivis Castalia</p>
+
+							<p class="frame__chara__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Cactuar&nbsp;(Aether)</p>
+						</div>
+					</a>
+					<div class="parts__connect--state js__toggle_trigger">
+
+
+						<i class="parts__connect_off js__tooltip" data-tooltip="You have no connection with this character."></i>
+
+					</div>
+
+					<div class="parts__switch js__toggle_item">
+
+						<p class="character__connect__text">You have no connection with this character.</p>
+
+
+
+
+
+						<div class="heading--md-slide">Follower Requests</div>
+						<p class="entry__toggle__text">Before this character can be followed, you must first submit a follower request.<br />Do you wish to proceed?</p>
+						<ul class="btn__switch character__connect__form">
+							<li><a href="/lodestone/account/login/">Yes</a></li>
+							<li><a href="javascript:void(0)" class="js__toggle_trigger">No</a></li>
+						</ul>
+
+
+
+					</div>
+
+				</div>
+
+				<ul class="character__profile_tab js__character_menu clearfix"><li><a href="javascript:void(0);" id="hash__profile" data-hash="profile">Profile</a></li><li class="character_menu__link"><a href="/lodestone/character/33000061/class_job/">Class/Job</a></li><li class="disable"><span class="disable">Minions</span></li><li class="character_menu__link"><a href="/lodestone/character/33000061/mount/">Mounts</a></li><li class="character_menu__link"><a href="/lodestone/character/33000061/following/">Follow</a></li></ul>
+
+
+
+
+				<div class="character__content selected">
+
+
+					<div class="heading__flex"><h3>Profile</h3><span class="heading__flex__text">Display Attributes</span><input class="character__tgl" id="toggle-profile" type="checkbox" disabled><label class="character__tgl-btn js__tooltip" for="toggle-profile" data-tooltip="Show Attributes" data-parameter_off="Show Attributes" data-parameter_on="Hide Attributes"></label></div><div class="character__profile clearfix"><div class="character__profile__data"><div class="js__character_toggle"><div class="character__profile__data__detail"><div class="character-block"><img src="https://img2.finalfantasyxiv.com/f/c89729f713c11518b5f0b660bdd42b41_96ab1df8877c1f8ba6a89a39cccfd437fc0_96x96.jpg?1642765243" width="32" height="32" alt="" class="character-block__face"><div class="character-block__box"><p class="character-block__title">Race/Clan/Gender</p><p class="character-block__name">Elezen<br />Duskwight / ♂</p></div></div><div class="character-block"><img src="https://img.finalfantasyxiv.com/lds/h/D/IaeQ866z-QseoMBt5GJFKtq9MM.png" width="32" height="32" alt=""><div class="character-block__box"><p class="character-block__title">Nameday</p><p class="character-block__birth">13th Sun of the 3rd Umbral Moon</p><p class="character-block__title">Guardian</p><p class="character-block__name">Althyk, the Keeper</p></div></div><div class="character-block"><img src="https://img.finalfantasyxiv.com/lds/h/j/Xlz3DzGOKmwiDGho5aGWaudRNI.png" width="32" height="32" alt=""><div class="character-block__box"><p class="character-block__title">City-state</p><p class="character-block__name">Limsa Lominsa</p></div></div></div></div><div class="js__character_toggle hide"><h3 class="heading--lead"><i class="icon-c--title icon-c__attributes"></i>Attributes</h3><table class="character__param__list"><tr><th><span class="js__tooltip" data-tooltip="Affects physical damage dealt by gladiator's arms, marauder's arms, pugilist's arms, lancer's arms, conjurer's arms, thaumaturge's arms, arcanist's arms, dark knight's arms, samurai's arms, reaper's arms, gunbreaker's arms, red mage's arms, astrologian's arms, sage's arms, and blue mage's arms.">Strength</span></th><td>41</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects physical ranged damage and damage dealt by rogue's arms.">Dexterity</span></th><td>45</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects maximum HP.">Vitality</span></th><td>49</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects attack magic potency when role is DPS.">Intelligence</span></th><td>65</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects healing magic potency. Also affects attack magic potency when role is Healer.">Mind</span></th><td>47</td></tr></table><h3 class="heading--lead"><i class="icon-c--title icon-c__offense"></i>Offensive Properties</h3><table class="character__param__list"><tr><th><span class="js__tooltip" data-tooltip="Affects the amount of physical and magic damage dealt, as well as HP restored. The higher the value, the higher the frequency with which your hits will be critical/higher the potency of critical hits.">Critical Hit Rate</span></th><td>97</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects the amount of damage dealt by both physical and magic attacks, as well as the amount of HP restored by healing spells.">Determination</span></th><td>46</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects the rate at which your physical and magic attacks land direct hits, slightly dealing more damage than normal hits. The higher the value, the higher the frequency with which your hits will be direct.">Direct Hit Rate</span></th><td>100</td></tr></table><h3 class="heading--lead"><i class="icon-c--title icon-c__deffense"></i>Defensive Properties</h3><table class="character__param__list"><tr><th><span class="js__tooltip" data-tooltip="Affects the amount of damage taken by physical attacks. The higher the value, the less damage taken.">Defense</span></th><td>59</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects the amount of damage taken by magic attacks. The higher the value, the less damage taken.">Magic Defense</span></th><td>98</td></tr></table><h3 class="heading--lead"><i class="icon-c--title icon-c__melle"></i>Physical Properties</h3><table class="character__param__list"><tr><th><span class="js__tooltip" data-tooltip="Affects amount of damage dealt by physical attacks. The higher the value, the more damage dealt.">Attack Power</span></th><td>41</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects both the casting and recast timers, as well as the damage over time potency for weaponskills and auto-attacks. The higher the value, the shorter the timers/higher the potency.">Skill Speed</span></th><td>96</td></tr></table><h3 class="heading--lead"><i class="icon-c--title icon-c__spell"></i>Mental Properties</h3><table class="character__param__list"><tr><th><span class="js__tooltip" data-tooltip="Affects the amount of damage dealt by magic attacks.">Attack Magic Potency</span></th><td>65</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects the amount of HP restored via healing magic.">Healing Magic Potency</span></th><td>47</td></tr><tr><th><span class="js__tooltip" data-tooltip="Affects both the casting and recast timers for spells. The higher the value, the shorter the timers. Also affects a spell's damage over time or healing over time potency.">Spell Speed</span></th><td>98</td></tr></table><h3 class="heading--lead"><i class="icon-c--title icon-c__role"></i>Role</h3><table class="character__param__list"><tr><th><span class="js__tooltip" data-tooltip="Affects the amount of physical and magic damage dealt and received, as well as HP restored. The higher the value, the more damage dealt, the more HP restored, and the less damage taken. Only applicable when role is Tank.">Tenacity</span></th><td>96</td></tr><tr><th class="pb-0"><span class="js__tooltip" data-tooltip="Affects MP regeneration. Regeneration rate is determined by piety. Only applicable when in battle and role is Healer.">Piety</span></th><td class="pb-0">46</td></tr></table></div></div><div class="character__profile__detail"><div class="character__view clearfix"><div class="character__class"><div class="character__class__arms"><div class="icon-c--0 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/22/22c0a8d28f85d64b923c7292120316d04a1dfc18.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/ef/ef7be042e4a77263c56d340f9cb286ef247c2f88.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Maple Picatrix</h2><p class="db-tooltip__item__category">Arcanist&#39;s Grimoire</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/332ea61bf42/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 8</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name">Magic Damage</div><div class="db-tooltip__item_spec__name">Auto-attack</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Delay</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value"><strong class="">13</strong></div><div class="db-tooltip__item_spec__value"><strong class="">12.82</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">2.96</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">ACN SMN SCH</div><div class="db-tooltip__item_equipment__level">Lv. 8</div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Intelligence</span> +2</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Alchemist Lv. 1</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 1 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>8.00</span></li><li>Dyeable: <span>No</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Maple%20Picatrix%22">358 gil</a></p><span><span class="db-tooltip__sells">Sells for </span>5 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div></div><div class="character__class__data"><p>LEVEL 15 </p><div class="character__class_icon"><img src="https://img.finalfantasyxiv.com/lds/h/e/VYP1LKTDpt8uJVvUT7OKrXNL9E.png" width="24" height="24" alt=""></div><img src="https://img.finalfantasyxiv.com/lds/h/2/V4RyOObRXzrVRraLoPhMui_Atg.png" width="266" height="28" alt="" class="character__classjob"></div></div><div class="character__detail"><div class="character__detail__icon"><div class="icon-c--2 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/fc/fc9fea75329659f3b969aa4d350154efff3be7cf.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="staining" style="background: #aca8a2;"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><div class="staining" style="background: #aca8a2;"></div><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/a7/a7c7b43b326760d9c2a297c29117950ccb82ddac.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/h/iMiPYBWuh22FtFJTn2coPIp0I0.png" width="20" height="20" class="js__tooltip" alt="Can have company crests applied." data-tooltip="Can have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Amateur&#39;s Hempen Coif</h2><p class="db-tooltip__item__category">Head</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/b7de935079f/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 10</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">10</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">17</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">All Classes</div><div class="db-tooltip__item_equipment__level">Lv. 10</div></div><hr class="db-tooltip__line"><div class="list_1col eorzeadb_tooltip_mb10"><div class="stain"><a href="/lodestone/playguide/db/item/c5917eabdaa/">Ash Grey Dye</a></div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Vitality</span> +1</li><li class=""><span>Intelligence</span> +1</li><li class=""><span>Mind</span> +1</li><li class=""><span>Direct Hit Rate</span> +1</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Weaver Lv. 1</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 1 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>10.00</span></li><li>Dyeable: <span>Yes</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Amateur%27s%20Hempen%20Coif%22">226 gil</a></p><span><span class="db-tooltip__sells">Sells for </span>4 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--3 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/2b/2b8e2da79ff4845b187f5e5a7eb8e1358fe099b8.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="staining" style="background: #373747;"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><div class="staining" style="background: #373747;"></div><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/22/220a42775e269eac901ec3fba743b0a892781008.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/h/iMiPYBWuh22FtFJTn2coPIp0I0.png" width="20" height="20" class="js__tooltip" alt="Can have company crests applied." data-tooltip="Can have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Amateur&#39;s Dalmatica</h2><p class="db-tooltip__item__category">Body</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/019305b4ff1/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 10</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">14</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">23</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">All Classes</div><div class="db-tooltip__item_equipment__level">Lv. 10</div></div><hr class="db-tooltip__line"><div class="list_1col eorzeadb_tooltip_mb10"><div class="stain"><a href="/lodestone/playguide/db/item/8d5806d8b72/">Shadow Blue Dye</a></div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Vitality</span> +1</li><li class=""><span>Intelligence</span> +2</li><li class=""><span>Mind</span> +2</li><li class=""><span>Direct Hit Rate</span> +2</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Weaver Lv. 1</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 1 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>10.00</span></li><li>Dyeable: <span>Yes</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Amateur%27s%20Dalmatica%22">280 gil</a></p><span><span class="db-tooltip__sells">Sells for </span>6 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--4 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/34/34119f4265fbd7015dbce0de495ee276f3184fe3.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="staining" style="background: #4f5766;"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><div class="staining" style="background: #4f5766;"></div><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/a6/a6902bab6772422d5ff2ded28e2523c22afd7e82.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Hempen Dress Gloves</h2><p class="db-tooltip__item__category">Hands</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/9d65800aa15/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 11</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">11</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">18</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">All Classes</div><div class="db-tooltip__item_equipment__level">Lv. 11</div></div><hr class="db-tooltip__line"><div class="list_1col eorzeadb_tooltip_mb10"><div class="stain"><a href="/lodestone/playguide/db/item/b036656bfda/">Ceruleum Blue Dye</a></div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Vitality</span> +1</li><li class=""><span>Intelligence</span> +1</li><li class=""><span>Mind</span> +1</li><li class=""><span>Direct Hit Rate</span> +1</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Weaver Lv. 1</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 2 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>11.00</span></li><li>Dyeable: <span>Yes</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Hempen%20Dress%20Gloves%22">224 gil</a></p><span><span class="db-tooltip__sells">Sells for </span>4 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--6 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/7c/7c4ca98f4ac2ef85e9618eca95a0920c189cf8d0.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="staining" style="background: #656565;"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><div class="staining" style="background: #656565;"></div><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/6e/6ed6bfc1878b38bfb4a6be1d9a0ca5d92ffcf570.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Amateur&#39;s Breeches</h2><p class="db-tooltip__item__category">Legs</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/97c959e8b01/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 10</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">14</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">23</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">All Classes</div><div class="db-tooltip__item_equipment__level">Lv. 10</div></div><hr class="db-tooltip__line"><div class="list_1col eorzeadb_tooltip_mb10"><div class="stain"><a href="/lodestone/playguide/db/item/2db18e9a29d/">Slate Grey Dye</a></div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Vitality</span> +1</li><li class=""><span>Intelligence</span> +2</li><li class=""><span>Mind</span> +2</li><li class=""><span>Spell Speed</span> +2</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Weaver Lv. 1</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 1 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>10.00</span></li><li>Dyeable: <span>Yes</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Amateur%27s%20Breeches%22">216 gil</a></p><span><span class="db-tooltip__sells">Sells for </span>6 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--7 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/cc/cce1137ec8868ea2a5dba679084197f030dce8ec.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="staining" style="background: #6a4b37;"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><div class="staining" style="background: #6a4b37;"></div><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/8d/8d65b418e104150d8dcd85ed419cf96dd5c3ee4b.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Amateur&#39;s Duckbills</h2><p class="db-tooltip__item__category">Feet</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/3cb6f21b282/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 10</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">10</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">17</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">All Classes</div><div class="db-tooltip__item_equipment__level">Lv. 10</div></div><hr class="db-tooltip__line"><div class="list_1col eorzeadb_tooltip_mb10"><div class="stain"><a href="/lodestone/playguide/db/item/09504c576f1/">Bark Brown Dye</a></div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Vitality</span> +1</li><li class=""><span>Intelligence</span> +1</li><li class=""><span>Mind</span> +1</li><li class=""><span>Critical Hit</span> +1</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Leatherworker Lv. 1</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 1 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>10.00</span></li><li>Dyeable: <span>Yes</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Amateur%27s%20Duckbills%22">230 gil</a></p><span><span class="db-tooltip__sells">Sells for </span>4 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div></div><div class="character__detail__image"><a href="https://img2.finalfantasyxiv.com/f/c89729f713c11518b5f0b660bdd42b41_96ab1df8877c1f8ba6a89a39cccfd437fl0_640x873.jpg?1642765243" class="js__image_popup"><img src="https://img2.finalfantasyxiv.com/f/c89729f713c11518b5f0b660bdd42b41_96ab1df8877c1f8ba6a89a39cccfd437fl0_640x873.jpg?1642765243" width="220" height="300" alt=""><img src="https://img.finalfantasyxiv.com/lds/h/U/ufiv3TIMncKieVNZc8xRk2ski0.png" width="32" height="32" class="character__detail__popup js__tooltip" data-tooltip="Enlarge Character Portrait "></a></div><div class="character__detail__icon"><div class="icon-c--1 ic_reflection_box js__db_tooltip"></div><div class="icon-c--8 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/6f/6fa193744637a6d1e7fea1bccbb4ea3d2e7144fd.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/6c/6c12667efbb64fd22d7971f9534f9d8b31680b27.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Weathered Earrings</h2><p class="db-tooltip__item__category">Earrings</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/18edb75b865/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 5</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">0</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">0</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">All Classes</div><div class="db-tooltip__item_equipment__level">Lv. 1</div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Strength</span> +1</li><li class=""><span>Dexterity</span> +1</li><li class=""><span>Vitality</span> +1</li><li class=""><span>Intelligence</span> +1</li><li class=""><span>Mind</span> +1</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Goldsmith Lv. 1</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 1 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>No</span></li><li>Dyeable: <span>No</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Weathered%20Earrings%22">168 gil</a></p><span><span class="db-tooltip__sells">Sells for </span>2 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--9 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/b0/b02466b5cd1313c721c5c8b013916d8eb17f28ab.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/a5/a5f02d68e77107ae2ae38bd450819b14438a1387.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Bone Necklace</h2><p class="db-tooltip__item__category">Necklace</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/8ea2fd66656/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 8</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">0</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">0</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">All Classes</div><div class="db-tooltip__item_equipment__level">Lv. 8</div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Intelligence</span> +1</li><li class=""><span>Mind</span> +1</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Goldsmith Lv. 1</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 1 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>8.00</span></li><li>Dyeable: <span>No</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Bone%20Necklace%22">156 gil</a></p><span><span class="db-tooltip__sells">Sells for </span>3 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--10 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/ca/ca9396ae6351b2c260042541db6280473c2927a5.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/55/55f85e3fe84b4b9e6751d56b71d431f14f992549.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Copper Wristlets</h2><p class="db-tooltip__item__category">Bracelets</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/712e7211081/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 8</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">0</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">0</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">All Classes</div><div class="db-tooltip__item_equipment__level">Lv. 8</div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Intelligence</span> +1</li><li class=""><span>Mind</span> +1</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Goldsmith Lv. 1</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 1 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>8.00</span></li><li>Dyeable: <span>No</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Copper%20Wristlets%22">229 gil</a></p><span><span class="db-tooltip__sells">Sells for </span>3 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--11 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/99/994f4be6f730e5d5389c2bfe57dfabe737358e20.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/b7/b78cad8290f917fc66041f8f2058815c56231a75.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Bone Ring</h2><p class="db-tooltip__item__category">Ring</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/a0de9889c4a/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 9</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">0</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">0</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">All Classes</div><div class="db-tooltip__item_equipment__level">Lv. 9</div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Intelligence</span> +1</li><li class=""><span>Mind</span> +1</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Goldsmith Lv. 1</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 1 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>9.00</span></li><li>Dyeable: <span>No</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Bone%20Ring%22">132 gil</a></p><span><span class="db-tooltip__sells">Sells for </span>3 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--12 ic_reflection_box js__db_tooltip"><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/77/77a2a6cfa9232761cb77fbf383beac9aeb9314ae.png?n6.05" width="40" height="40" alt="" class="character__item_icon__img"><div class="character__item_icon character__item_icon--frame"></div><div class="db-tooltip db-tooltip__wrapper item_detail_box"><div class="db-tooltip__l_main"><div class="popup_w412_body_gold"><div class="clearfix"><div class="db-tooltip__header clearfix"><div class="db-tooltip__item__icon"><img src="https://img.finalfantasyxiv.com/lds/h/I/3yf_x6lEOM5blcAMdAeRiyZc2A.png" width="76" height="76" alt=""><img src="https://img.finalfantasyxiv.com/lds/pc/global/images/itemicon/19/1941591b5bd246e071d2521b73100c07069495bc.png?n6.05" width="64" height="64" alt="" class="db-tooltip__item__icon__item_image"><div class="db-tooltip__item__icon__cover"></div></div><div class="db-tooltip__item__txt"><div class="db-tooltip__item__element"><ul class="db-tooltip__item__storage"><li><img src="https://img.finalfantasyxiv.com/lds/h/C/GCeqpMdmlXy1eMmi0K_899AWnA.png" width="20" height="20" class="js__tooltip" alt="Cannot have company crests applied." data-tooltip="Cannot have company crests applied."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/A/te5gEgEroS6xWX-bPrAVizJcSg.png" width="20" height="20" class="js__tooltip" alt="Can be placed in a glamour dresser." data-tooltip="Can be placed in a glamour dresser."></li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/oa00pPEkTk1Mc-dDLmJ7mc2h4o.png" width="20" height="20" class="js__tooltip" alt="Cannot be placed in an armoire." data-tooltip="Cannot be placed in an armoire."></li></ul></div><h2 class="db-tooltip__item__name 	txt-rarity_common">Weathered Ring</h2><p class="db-tooltip__item__category">Ring</p></div></div></div><div class="db-tooltip__bt_item_detail"><a href="/lodestone/playguide/db/item/80ab609c7cf/"><img src="https://img.finalfantasyxiv.com/lds/h/J/YW76_G2zKdEnsPJVgE28mpzqkY.png" width="300" height="60" alt="View Item Details"></a></div><div class="db-tooltip__item__level ">Item Level 5</div><div class="db-popup__inner"><div class="db-tooltip__item_spec"><div class="clearfix"><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--armor">Defense</div><div class="db-tooltip__item_spec__name db-tooltip__item_spec__name--last">Magic Defense</div></div><div class="clearfix"><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--armor"><strong class="">0</strong></div><div class="db-tooltip__item_spec__value db-tooltip__item_spec__value--last"><strong class="">0</strong></div></div></div></div><div class="db-popup__inner"><div class="db-tooltip__item_equipment"><div class="db-tooltip__item_equipment__class">All Classes</div><div class="db-tooltip__item_equipment__level">Lv. 1</div></div><h3 class="db-tooltip__sub_title">Bonuses</h3><hr class="db-tooltip__line"><ul class="db-tooltip__basic_bonus"><li class=""><span>Strength</span> +1</li><li class=""><span>Dexterity</span> +1</li><li class=""><span>Vitality</span> +1</li><li class=""><span>Intelligence</span> +1</li><li class=""><span>Mind</span> +1</li></ul><h3 class="db-tooltip__sub_title">Crafting & Repairs</h3><hr class="db-tooltip__line"><ul class="db-tooltip__item_repair"><li><span class="db-tooltip__item_repair__title">Durability</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Spiritbond</span><span>???%</span></li><li><span class="db-tooltip__item_repair__title">Repair Level</span><span>Goldsmith Lv. 1</span></li><li><span class="db-tooltip__item_repair__title">Materials</span><span>Grade 1 Dark Matter</span></li></ul><ul class="db-tooltip__item-info__list"><li>Extractable: <span>Yes</span></li><li>Projectable: <span>Yes</span></li><li>Desynthesizable: <span>No</span></li><li>Dyeable: <span>No</span></li></ul></div><div class="db-popup__inner"><hr class="db-tooltip__line"><div class="db-tooltip__item_footer"><p><span class="db-view__sells">Sale Price: </span><a href="/lodestone/playguide/db/shop/?category2=gil&amp;q=%22Weathered%20Ring%22">168 gil</a></p><span><span class="db-tooltip__sells">Sells for </span>2 gil</span><span class="db-tooltip__market_notsell">Market Prohibited</span></div></div></div></div></div></div><div class="icon-c--13 ic_reflection_box js__db_tooltip"></div></div></div></div><div class="js__character_toggle"><div class="character__level clearfix"><div class="character__level__list"><ul><li><img src="https://img.finalfantasyxiv.com/lds/h/U/F5JzG9RPIKFSogtaKNBk455aYA.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Gladiator">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/N/St9rjDJB3xNKGYg-vwooZ4j6CM.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Marauder">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/l/5CZEvDOMYMyVn2td9LZigsgw9s.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Dark Knight">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/8/hg8ofSSOKzqng290No55trV4mI.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Gunbreaker">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/s/gl62VOTBJrm7D_BmAZITngUEM8.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Conjurer">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/7/WdFey0jyHn9Nnt1Qnm-J3yTg5s.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Scholar">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/1/erCgjnMSiab4LiHpWxVc-tXAqk.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Astrologian">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/g/_oYApASVVReLLmsokuCJGkEpk0.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Sage">-</li></ul></div></div><div class="character__level clearfix"><div class="character__level__list"><ul><li><img src="https://img.finalfantasyxiv.com/lds/h/V/iW7IBKQ7oglB9jmbn6LwdZXkWw.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Pugilist">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/k/tYTpoSwFLuGYGDJMff8GEFuDQs.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Lancer">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/y/wdwVVcptybfgSruoh8R344y_GA.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Rogue">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/m/KndG72XtCFwaq1I1iqwcmO_0zc.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Samurai">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/7/cLlXUaeMPJDM2nBhIeM-uDmPzM.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Reaper">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/Q/ZpqEJWYHj9SvHGuV9cIyRNnIkk.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Archer">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/E/vmtbIlf6Uv8rVp2YFCWA25X0dc.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Machinist">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/t/HK0jQ1y7YV9qm30cxGOVev6Cck.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Dancer">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/4/IM3PoP6p06GqEyReygdhZNh7fU.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Thaumaturge">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/e/VYP1LKTDpt8uJVvUT7OKrXNL9E.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Arcanist">15</li><li><img src="https://img.finalfantasyxiv.com/lds/h/q/s3MlLUKmRAHy0pH57PnFStHmIw.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Red Mage">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/p/jdV3RRKtWzgo226CC09vjen5sk.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Blue Mage (Limited Job)">-</li></ul></div></div><div class="character__level clearfix"><div class="character__level__list"><ul><li><img src="https://img.finalfantasyxiv.com/lds/h/v/YCN6F-xiXf03Ts3pXoBihh2OBk.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Carpenter">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/5/EEHVV5cIPkOZ6v5ALaoN5XSVRU.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Blacksmith">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/G/Rq5wcK3IPEaAB8N-T9l6tBPxCY.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Armorer">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/L/LbEjgw0cwO_2gQSmhta9z03pjM.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Goldsmith">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/b/ACAcQe3hWFxbWRVPqxKj_MzDiY.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Leatherworker">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/X/E69jrsOMGFvFpCX87F5wqgT_Vo.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Weaver">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/C/bBVQ9IFeXqjEdpuIxmKvSkqalE.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Alchemist">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/m/1kMI2v_KEVgo30RFvdFCyySkFo.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Culinarian">-</li></ul></div></div><div class="character__level clearfix"><div class="character__level__list"><ul><li><img src="https://img.finalfantasyxiv.com/lds/h/A/aM2Dd6Vo4HW_UGasK7tLuZ6fu4.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Miner">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/I/jGRnjIlwWridqM-mIPNew6bhHM.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Botanist">-</li><li><img src="https://img.finalfantasyxiv.com/lds/h/x/B4Azydbn7Prubxt7OL9p1LZXZ0.png" width="24" height="24" alt="" class="js__tooltip"data-tooltip="Fisher">-</li></ul></div></div></div><div class="js__character_toggle hide"><div class="character__param"><ul><li><div><p class="character__param__text character__param__text__hp--en-gb">HP</p><span>246</span></div><i class="character__param--hp"></i></li><li><div><p class="character__param__text character__param__text__mp--en-gb">MP</p><span>10000</span></div><i class="character__param--mp"></i></li></ul></div></div></div></div><div class="heading__icon parts__space--reset"><h3>Character Profile</h3></div><div class="character__selfintroduction">-</div>
+
+
+					<div class="btn__comment">
+
+
+					</div>
+
+
+
+
+
+					<ul class="social__btn"><li><a href="http://www.facebook.com/share.php?u=https://eu.finalfantasyxiv.com/lodestone/character/33000061" target="_blank"><i class="xiv-lds xiv-lds-facebook js__tooltip" data-tooltip="Share"></i></a></li><li><a href="https://twitter.com/share?url=https://eu.finalfantasyxiv.com/lodestone/character/33000061&text=Ivis%20Castalia%20%7C%20FINAL%20FANTASY%20XIV%2C%20The%20Lodestone" target="_blank"><i class="xiv-lds xiv-lds-twitter js__tooltip" data-tooltip="Tweet"></i></a></li></ul>
+
+				</div>
+
+				<div class="character__content"></div><div class="character__content"></div><div class="character__content"></div><div class="character__content"></div>
+			</div>
+		</div>
+
+		<div class="ldst__side">
+
+
+
+
+			<div class="l__rside__bnr clearfix">
+				<a href="https://forum.square-enix.com/ffxiv/forum.php?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_forum" target="_blank" class="l__rside__bnr--forums"><img src="https://img.finalfantasyxiv.com/lds/h/i/i3r6u3moBzQFfijSTu9k3EJirQ.png" width="100" height="62" alt="Forums"></a><a href="https://sqex.to/Msp?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_mogstation" target="_blank" class="l__rside__bnr--mog_station"><img src="https://img.finalfantasyxiv.com/lds/h/3/GjsnqfVxPQrE4Jve8GvKZABF5w.png" width="100" height="62" alt="Mog Station"></a><a href="/pr/blog/?utm_source=lodestone&utm_medium=pc_banner&utm_campaign=eu_officalblog" target="_blank" class="l__rside__bnr--blog"><img src="https://img.finalfantasyxiv.com/lds/h/d/nVeXvIIStLv3npokivV0EzkKwI.png" width="100" height="62" alt="Official Blog"></a>
+			</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+			<div class="mb10"><a href="/endwalker/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_endwalker"><img src="https://img.finalfantasyxiv.com/lds/banner/998/v60_211207_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="https://store.finalfantasyxiv.com/ffxivstore/en-gb/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_onlinestore" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/banner/916/LDS_ffxivos_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/special/2022/All_Saints_Wake/rjk7wevhuy?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_all_saints_wake"><img src="https://img.finalfantasyxiv.com/lds/banner/1119/mnbn_all_saints_wake-1_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/community_finder/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_cf202112"><img src="https://img.finalfantasyxiv.com/lds/banner/1104/LDS_CF_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/jobguide/battle/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_jobguide"><img src="https://img.finalfantasyxiv.com/lds/banner/1089/jobguide_v60_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/uiguide/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_uiguide"><img src="https://img.finalfantasyxiv.com/lds/banner/671/pc_uiguide_eu.jpg"></a></div>
+
+
+
+			<div class="conducting_area">
+
+				<img src="https://img.finalfantasyxiv.com/lds/h/z/EhLfs3eya3Aidfr8A6PbXOBgtA.png" width="300" height="218" alt="">
+
+				<div class="inr">
+					<a href="
+				http://freetrial.finalfantasyxiv.com/" class="bt_conducting">
+						<img src="https://img.finalfantasyxiv.com/lds/h/s/3KRua4vzZJvRXn0IMk8Da103bw.png" width="284" height="80" alt="Start Your Free Trial">
+					</a>
+					<a href="/product/?utm_source=lodestone&utm_medium=pc_buyarea&utm_campaign=eu_buynow" class="bt_conducting" target="_blank">
+						<img src="https://img.finalfantasyxiv.com/lds/h/p/to8CzK_gktAHpLuSGzCkNdLfWo.png" width="284" height="80" alt="BUY NOW!">
+					</a>			<a href="https://support.eu.square-enix.com/faqarticle.php?id=5383&la=2&kid=78775" onmousedown="ga('send', 'event', 'lodestone_eu', 'howtoupgrade_link', 'EU-lodestone-UG_20170620', true);" class="bt_ft_migration">			<img src="https://img.finalfantasyxiv.com/lds/h/0/5rrJdYAcP3if6zX6d62dHV3t34.png" width="260" height="80" alt="Upgrade Your Free Trial<br />to the Full Version">
+				</a>
+				</div>
+			</div>
+
+
+
+
+
+
+
+
+
+			<div class="mb10"><a href="/tales_of_adventure/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_tales_of_adventure"><img src="https://img.finalfantasyxiv.com/lds/banner/1079/LDS_Tales_of_Adventure_v60_eu.jpg"></a></div>
+
+
+
+			<div class="mb10"><a href="/lodestone/special/friend_recruit/?utm_source=lodestone&amp;utm_medium=pc_banner&amp;utm_campaign=eu_friendrecruit"><img src="https://img.finalfantasyxiv.com/lds/banner/203/bn_Recruit_a_Friend_eu.png"></a></div>
+
+
+
+
+
+
+			<div class="ldst__side__box">
+
+
+
+				<div class="heading--side">
+					<h3>Community Wall</h3>
+					<a href="/lodestone/community/" class="heading--side__icon icon-list__side js__tooltip" data-tooltip="See More"></a>
+				</div>
+				<div class="heading__icon parts__space--reset js__toggle_wrapper">
+					<h4>Recent Activity</h4>
+					<i class="icon-btn__filter js__toggle_trigger js__tooltip" data-tooltip="Filter"></i>
+					<div class="parts__switch parts__switch--filter js__toggle_item">
+						<p class="parts__text">
+							Filter which items are to be displayed below.<br>
+							<span class="parts__text__notes">
+				* Notifications for standings updates are shared across all Worlds.<br>
+				* Notifications for PvP team formations are shared for all languages.<br>
+				* Notifications for free company formations are shared for all languages.
+			</span>
+						</p>
+
+
+						<div class="form__horizontal js__communitywall_filter">
+							<input type="hidden" name="order" value=""><h5 class="heading--side--lead">Sort by</h5><ul class="form__row parts__spce--8"><li><input type="checkbox" name="community_type" value="blog" class="form__checkbox" id="community_type01"><label class="form__checkbox__label" for="community_type01">Blog</label></li><li><input type="checkbox" name="community_type" value="event" class="form__checkbox" id="community_type02"><label class="form__checkbox__label" for="community_type02">Event & Party Recruitment</label></li><li><input type="checkbox" name="community_type" value="fc" class="form__checkbox" id="community_type03"><label class="form__checkbox__label" for="community_type03">Free Company</label></li><li><input type="checkbox" name="community_type" value="db" class="form__checkbox" id="community_type04"><label class="form__checkbox__label" for="community_type04">Eorzea Database</label></li><li><input type="checkbox" name="community_type" value="ranking" class="form__checkbox" id="community_type05"><label class="form__checkbox__label" for="community_type05">Standings</label></li><li><input type="checkbox" name="community_type" value="pvpteam" class="form__checkbox" id="community_type06"><label class="form__checkbox__label" for="community_type06">PvP Team</label></li><li><input type="checkbox" name="community_type" value="community_finder" class="form__checkbox" id="community_type07"><label class="form__checkbox__label" for="community_type07">Community Finder</label></li></ul><h5 class="heading--side--lead">Data Center / Home World</h5><div class="select-pulldown"><label class="control-label" for="world"></label><select name="community_worldname" class="select-pulldown__open"><option value="">Select All</option><optgroup label="Data Center"><option value="_dc_Elemental">Elemental</option><option value="_dc_Gaia">Gaia</option><option value="_dc_Mana">Mana</option><option value="_dc_Aether">Aether</option><option value="_dc_Primal">Primal</option><option value="_dc_Crystal">Crystal</option><option value="_dc_Chaos">Chaos</option><option value="_dc_Light">Light</option></optgroup><optgroup label="Home World"><option value="Adamantoise">Adamantoise</option><option value="Aegis">Aegis</option><option value="Alexander">Alexander</option><option value="Anima">Anima</option><option value="Asura">Asura</option><option value="Atomos">Atomos</option><option value="Bahamut">Bahamut</option><option value="Balmung">Balmung</option><option value="Behemoth">Behemoth</option><option value="Belias">Belias</option><option value="Brynhildr">Brynhildr</option><option value="Cactuar">Cactuar</option><option value="Carbuncle">Carbuncle</option><option value="Cerberus">Cerberus</option><option value="Chocobo">Chocobo</option><option value="Coeurl">Coeurl</option><option value="Diabolos">Diabolos</option><option value="Durandal">Durandal</option><option value="Excalibur">Excalibur</option><option value="Exodus">Exodus</option><option value="Faerie">Faerie</option><option value="Famfrit">Famfrit</option><option value="Fenrir">Fenrir</option><option value="Garuda">Garuda</option><option value="Gilgamesh">Gilgamesh</option><option value="Goblin">Goblin</option><option value="Gungnir">Gungnir</option><option value="Hades">Hades</option><option value="Hyperion">Hyperion</option><option value="Ifrit">Ifrit</option><option value="Ixion">Ixion</option><option value="Jenova">Jenova</option><option value="Kujata">Kujata</option><option value="Lamia">Lamia</option><option value="Leviathan">Leviathan</option><option value="Lich">Lich</option><option value="Louisoix">Louisoix</option><option value="Malboro">Malboro</option><option value="Mandragora">Mandragora</option><option value="Masamune">Masamune</option><option value="Mateus">Mateus</option><option value="Midgardsormr">Midgardsormr</option><option value="Moogle">Moogle</option><option value="Odin">Odin</option><option value="Omega">Omega</option><option value="Pandaemonium">Pandaemonium</option><option value="Phoenix">Phoenix</option><option value="Ragnarok">Ragnarok</option><option value="Ramuh">Ramuh</option><option value="Ridill">Ridill</option><option value="Sargatanas">Sargatanas</option><option value="Shinryu">Shinryu</option><option value="Shiva">Shiva</option><option value="Siren">Siren</option><option value="Spriggan">Spriggan</option><option value="Tiamat">Tiamat</option><option value="Titan">Titan</option><option value="Tonberry">Tonberry</option><option value="Twintania">Twintania</option><option value="Typhon">Typhon</option><option value="Ultima">Ultima</option><option value="Ultros">Ultros</option><option value="Unicorn">Unicorn</option><option value="Valefor">Valefor</option><option value="Yojimbo">Yojimbo</option><option value="Zalera">Zalera</option><option value="Zeromus">Zeromus</option><option value="Zodiark">Zodiark</option></optgroup></select></div><h5 class="heading--side--lead">Primary language</h5><div class="select-pulldown"><label class="control-label" for="lang"></label><select name="community_lang" class="select-pulldown__open"><option value="">Select All</option><option value="ja">Japanese</option><option value="en">English</option><option value="de">German</option><option value="fr">French</option></select></div><h5 class="heading--side--lead">Displaying</h5><div class="select-pulldown"><label class="control-label" for="limit"></label><select name="community_limit" class="select-pulldown__open"><option value="10">10</option><option value="20">20</option><option value="30">30</option></select></div><div class="form__submit form__submit--full"><input type="submit" value="Filter" class="js__bt_communitywall_filter"></div>
+						</div>
+
+
+					</div>
+				</div>
+
+
+				<ul class="side__list__box">
+
+
+					<div class="entry more_"><a href="/lodestone/character/21923792/blog/4942246/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-5564c8d7d03" class="datetime_dynamic_ymdhm" data-epoch="1642765271">-</span><script>document.getElementById('datetime-5564c8d7d03').innerHTML = ldst_strftime_dynamic_ymdhm(1642765271);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Moko-steller Herzton</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ifrit&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Moko-steller Herzton (<i class="xiv-lds xiv-lds-home-world"></i>Ifrit) posted a new blog entry, "辺獄編クリアした感想."</p></div></div></div></a><a href="/lodestone/character/21923792/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/4d2543fd4ac79776e528bdfb9183a801_f9f796348bc43067c7242ec4551cde69fc0_96x96.jpg?1642762509" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/freecompany/9236882835737018846/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header--common clearfix"><time class="entry__activity__time"><span id="datetime-b819a02ad10" class="datetime_dynamic_ymdhm" data-epoch="1642765249">-</span><script>document.getElementById('datetime-b819a02ad10').innerHTML = ldst_strftime_dynamic_ymdhm(1642765249);</script></time></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__fc js__tooltip"data-tooltip="Free Company"></span></div><div class="entry__activity__txt--message"><p>HanaBank (Masamune) has been formed.</p></div></div></div></a><div class="entry__activity__link"><img src="https://img.finalfantasyxiv.com/lds/h/9/_Huf58epDlt9vXiO8IIfPXxtXI.png" width="50" height="50" alt=""></div></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/29420884/blog/4942243/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-a9027f4abb5" class="datetime_dynamic_ymdhm" data-epoch="1642765009">-</span><script>document.getElementById('datetime-a9027f4abb5').innerHTML = ldst_strftime_dynamic_ymdhm(1642765009);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Charis Prmeria</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Garuda&nbsp;(Elemental)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Charis Prmeria (<i class="xiv-lds xiv-lds-home-world"></i>Garuda) posted a new blog entry, "★Garuda★ FCメンバー募集中！."</p></div></div></div></a><a href="/lodestone/character/29420884/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/3e068e8db1635bcc48ce4583c3bd57ef_fcb1f5b0249d1069e5bdc66d0796f26afc0_96x96.jpg?1642762064" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/community_finder/5a97f8a127ca89d8fa9190c94babc23b253d1753/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-57e6e5d9234" class="datetime_dynamic_ymdhm" data-epoch="1642764812">-</span><script>document.getElementById('datetime-57e6e5d9234').innerHTML = ldst_strftime_dynamic_ymdhm(1642764812);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Sayuri Kuroyuki</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Cerberus&nbsp;(Chaos)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__community_finder js__tooltip"data-tooltip="Community Finder"></span></div><div class="entry__activity__txt--message"><p>Sayuri Kuroyuki (<i class="xiv-lds xiv-lds-home-world"></i>Cerberus) has started recruitment for the free company "No Solution (Cerberus)."</p></div></div></div></a><a href="/lodestone/character/9018393/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/bd14d70b0db26821b02b799bb4fd9f46_777c57311d510ca65dac3c1077dee435fc0_96x96.jpg?1642763258" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/22234/blog/4941345/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-a2edad95a18" class="datetime_dynamic_ymdhm" data-epoch="1642764696">-</span><script>document.getElementById('datetime-a2edad95a18').innerHTML = ldst_strftime_dynamic_ymdhm(1642764696);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Wao Miqotte</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Aegis&nbsp;(Elemental)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Wao Miqotte (<i class="xiv-lds xiv-lds-home-world"></i>Aegis) posted a new blog entry, "Lv83 インペリアル・ストライカー装備「ミコちゃんに叱られる！」ミラプリっ‼︎."</p></div></div></div></a><a href="/lodestone/character/22234/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/19bf3a0dfa9eadd8da9619ac17dbd99a_3ea38e723c590aabf186367e1eb7e6a1fc0_96x96.jpg?1642763835" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/41253362/blog/4942240/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-d9cda2d7156" class="datetime_dynamic_ymdhm" data-epoch="1642764544">-</span><script>document.getElementById('datetime-d9cda2d7156').innerHTML = ldst_strftime_dynamic_ymdhm(1642764544);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Jana Noe</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ultima&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Jana Noe (<i class="xiv-lds xiv-lds-home-world"></i>Ultima) posted a new blog entry, "一筋縄ではいかない守護天節."</p></div></div></div></a><a href="/lodestone/character/41253362/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/99b7cec774fcf1265e0c5cb067009ed1_9df1b3cb0da35db33c17ef11ddf12adafc0_96x96.jpg?1642765402" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/32506355/blog/4942239/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-0164e118be6" class="datetime_dynamic_ymdhm" data-epoch="1642764507">-</span><script>document.getElementById('datetime-0164e118be6').innerHTML = ldst_strftime_dynamic_ymdhm(1642764507);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Yuki Sternen</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ramuh&nbsp;(Elemental)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Yuki Sternen (<i class="xiv-lds xiv-lds-home-world"></i>Ramuh) posted a new blog entry, "豪華な夕食（及びサーバ移転のご報告）."</p></div></div></div></a><a href="/lodestone/character/32506355/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/a46765e58b325824f76a243b51483548_410ddb5a66a2fcacf538bec5ea5d0291fc0_96x96.jpg?1642761957" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/character/4060849/blog/4942237/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-f9c3086f818" class="datetime_dynamic_ymdhm" data-epoch="1642764252">-</span><script>document.getElementById('datetime-f9c3086f818').innerHTML = ldst_strftime_dynamic_ymdhm(1642764252);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Bridget Cowgirl</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Bahamut&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__blog js__tooltip"data-tooltip="Blog"></span></div><div class="entry__activity__txt--message"><p>Bridget Cowgirl (<i class="xiv-lds xiv-lds-home-world"></i>Bahamut) posted a new blog entry, "時期外れの守護天節が来た！."</p></div></div></div></a><a href="/lodestone/character/4060849/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/bae399e646df13b3457a4d1a4b5c3ad9_86da943caa70c8694707ab2ff74e68c9fc0_96x96.jpg?1642762434" width="40" height="40" alt=""></div></a></div>
+
+
+					<div class="entry more_"><a href="/lodestone/community_finder/4ac14490ddb5f4ae48c1e8caadb4c7dc46a87e2c/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-c2291982d3f" class="datetime_dynamic_ymdhm" data-epoch="1642764216">-</span><script>document.getElementById('datetime-c2291982d3f').innerHTML = ldst_strftime_dynamic_ymdhm(1642764216);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Rutile Lupinus</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Fenrir&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__community_finder js__tooltip"data-tooltip="Community Finder"></span></div><div class="entry__activity__txt--message"><p>Rutile Lupinus (<i class="xiv-lds xiv-lds-home-world"></i>Fenrir) has started recruitment for the free company "Natto-Gohan (Fenrir)."</p></div></div></div></a><a href="/lodestone/character/30453207/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/761e5ae5634f51f240413bd90e44119d_d384cf5ad7db803f29799f36ebbc3eadfc0_96x96.jpg?1642762921" width="40" height="40" alt=""></div></a></div>
+
+
+					<div data-min_id="4838291234" class="entry more_"data-has_next=""><a href="/lodestone/community_finder/3aa64d7d2cfe314a0aa2ea263ce760b0428283c0/" class="entry__activity"><div class="entry__activity__box"><div class="entry__activity__box__header clearfix"><time class="entry__activity__time"><span id="datetime-3d5fd7d8e24" class="datetime_dynamic_ymdhm" data-epoch="1642764156">-</span><script>document.getElementById('datetime-3d5fd7d8e24').innerHTML = ldst_strftime_dynamic_ymdhm(1642764156);</script></time><div class="entry__activity__data"><p class="entry__activity__data--name">Ai Dairokutenmao</p><p class="entry__activity__data--world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Tiamat&nbsp;(Gaia)</p></div></div><div class="entry__activity__txt"><div class="entry__activity__txt--icon"><span class="icon-activity__community_finder js__tooltip"data-tooltip="Community Finder"></span></div><div class="entry__activity__txt--message"><p>Ai Dairokutenmao (<i class="xiv-lds xiv-lds-home-world"></i>Tiamat) has started recruitment for the free company "BlueMoon Revolutions (Tiamat)."</p></div></div></div></a><a href="/lodestone/character/3276729/" class="entry__activity__link"><div class="entry__chara__face"><img src="https://img2.finalfantasyxiv.com/f/ba913fdf2b75379a40c2e05dced7ac83_9f10d335198e90990f3437c5733468e7fc0_96x96.jpg?1642762900" width="40" height="40" alt=""></div></a></div>
+
+
+
+
+				</ul>
+
+
+			</div>
+
+
+
+			<div class="ldst__side__box">
+
+
+
+
+				<div class="heading--side">
+					<h3>Standings</h3>
+					<a href="/lodestone/ranking/" class="heading--side__icon icon-list__side js__tooltip" data-tooltip="See More"></a>
+				</div>
+
+
+				<h4 class="heading--side--sm">The Feast Rankings</h4>
+
+				<a href="/lodestone/ranking/thefeast/result/" class="entry__ranking__thefeast">
+					Pre-season is under way!<br>
+					View results of the previous season
+				</a>
+
+
+
+
+				<h4 class="heading--side--sm">Grand Company Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Luke Breitner</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Fenrir&nbsp;(Gaia)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/9658201/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/bb7875f35a390ed9493dfde91c4d0039_d384cf5ad7db803f29799f36ebbc3eadfc0_96x96.jpg?1642762694" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Kiryuin Satsuki</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/7250925/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/ba64ef52323ad0c23edaa3bafc9f4e82_58a84e851e55175d22158ca97af58a1ffc0_96x96.jpg?1642764909" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/gc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Ari Nuovo</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Phoenix&nbsp;(Light)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/19970354/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/1eb1b6c06bbadecb3c0f3b8cbb1b07e0_5047bc596a4bab2dc7f7c120bb22dec5fc0_96x96.jpg?1642762546" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+				</ul>
+
+
+
+				<h4 class="heading--side--sm">Free Company Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">brotherhood</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Moogle&nbsp;(Chaos)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9233364398528115650/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/F00_f4d64b4d75ce7d3be3ba37e24ccc7830_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S01_49d2902352dde56ae3c6423a937ac151_00_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">The Syndicate</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9231394073691073564/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/B08_de875598ba3f5ef9fe02858d29c85455_33_40x40.png" width="40" height="40">
+
+							<img src="https://img2.finalfantasyxiv.com/c/F1e_ed8a164ee0086dc3e36d078e76126110_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S5c_c48179b4e96cff6ed7c51da16ca90c11_04_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/fc/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">CatOfHeart</p>
+
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Masamune&nbsp;(Mana)</p>
+							</div>
+						</a>
+						<a href="/lodestone/freecompany/9236882835737003825/" class="entry__ranking__crest">
+
+
+
+							<img src="https://img2.finalfantasyxiv.com/c/B0f_8c3fc97865a1c6bfa360c1bce22b9fa0_c0_40x40.png" width="40" height="40">
+
+							<img src="https://img2.finalfantasyxiv.com/c/F04_1223707ec2cfc1bde4ba8f0f85a74b24_00_40x40.png" width="40" height="40">
+							<img src="https://img2.finalfantasyxiv.com/c/S33_f0483d3975a483769f674866ff99675e_01_40x40.png" width="40" height="40">
+
+
+						</a>
+					</li>
+
+				</ul>
+
+
+
+				<h4 class="heading--side--sm">Frontline Standings</h4>
+
+				<ul>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								1
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Pharis Bloodborne</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Ragnarok&nbsp;(Chaos)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/7338237/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/553c62b150030202afb4206e6f758b91_40d57ba713628f3f1ef5ef204b6d76d2fc0_96x96.jpg?1642764063" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								2
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Ni Xi</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Malboro&nbsp;(Crystal)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/34789289/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/356072546b70540163fcdc5bf3f1a6f3_2e97c13fdd593d15d543093f8a37b6f0fc0_96x96.jpg?1642762869" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Blueberry Lollipop</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Siren&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/39019280/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/2be5c15e35dbd1670f814874fff1234b_58a84e851e55175d22158ca97af58a1ffc0_96x96.jpg?1642764072" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Jo Se</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Sargatanas&nbsp;(Aether)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/36466361/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/c9e98a67d1423c12fa7b4c38a41e80e0_ba22853447012a24cee115315d6a5bebfc0_96x96.jpg?1642763672" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+					<li class="entry__ranking">
+						<a href="/lodestone/ranking/frontline/weekly/" class="entry__ranking__link">
+							<p class="entry__ranking__rank">
+								3
+							</p>
+							<div class="entry__ranking__data">
+								<p class="entry__name">Kayeson Mon&#39;roux</p>
+								<p class="entry__world"><i class="xiv-lds xiv-lds-home-world js__tooltip" data-tooltip="Home World"></i>Leviathan&nbsp;(Primal)</p>
+							</div>
+						</a>
+
+						<a href="/lodestone/character/36261740/" class="entry__ranking__face">
+							<img src="https://img2.finalfantasyxiv.com/f/f44e37565c9e753a163ffc1a0d5105ea_a91aae52cff9ef65932db06b150ffd47fc0_96x96.jpg?1642762411" width="50" height="50" alt="">
+						</a>
+
+					</li>
+
+				</ul>
+
+
+			</div>
+
+
+
+
+
+
+
+
+
+
+		</div>
+
+	</div>
+
+</div>
+
+
+
+<div id="link_spsite" class="link_sp-site"><a href="javascript:void(0)">Mobile Version</a><br></div><footer class="l__footer l__footer__eu"><div class="page-top"><span class="page-top__btn"></span></div><div class="l__footer__inner"><div class="l__footer__logo"><img src="https://img.finalfantasyxiv.com/lds/h/L/EbtcXqPUGzsVYdi23FpUR25oH4.png" width="320" height="32" alt=""></div><p class="l__footer__officiel">Official Information</p><ul class="l__footer__sns"><li><a href="https://www.facebook.com/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-facebook xiv-lds-3x"></i><span>Facebook</span></a></li><li class="l__footer__sns--twitter"><a href="https://twitter.com/ff_xiv_en" target="_blank"><i class="xiv-lds xiv-lds-twitter xiv-lds-3x"></i>Twitter</a> / <a href="https://twitter.com/FFXIV_NEWS_EN" target="_blank">Twitter News</a></li><li><a href="http://www.youtube.com/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-youtube xiv-lds-3x"></i><span>Official Channel</span></a></li><li><a href="https://www.instagram.com/ffxiv/" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-instagram xiv-lds-3x"></i><span>Instagram</span></a></li><li><a href="https://www.twitch.tv/finalfantasyxiv" target="_blank" class="l__footer__sns--link"><i class="xiv-lds xiv-lds-twitch xiv-lds-3x"></i><span>Twitch</span></a></li></ul><ul class="l__footer__link-list"><li class="link_license" id="link_license"><a href="/license/" target="_blank">License</a></li><li><a href="https://support.eu.square-enix.com/rule.php?id=5383&la=2" target="_blank">Rules & Policies</a></li><li><a href="https://square-enix-games.com/en_GB/documents/privacy" target="_blank">Privacy Policy</a></li><li><a href="https://square-enix-games.com/en_GB/documents/cookies" target="_blank">Cookie Policy</a></li></ul></div><div class="l__footer__legal-area"><div class="l__footer__legal-area__inner clearfix"><div class="l__footer__legal-area__box"><ul class="l__footer__legal-area__bnr-list"><li><a href="http://www.pegi.info" target="_blank"><img src="https://img.finalfantasyxiv.com/lds/h/8/bLhWLeqRDavUCuBhK8X0yB9bKA.png" width="41" height="50" alt="PEGI"></a></li><li><img src="https://img.finalfantasyxiv.com/lds/h/D/egrXwtjrQC8nFGhA1rWb0PO8R0.png" width="245" height="39" alt="PlayStation PS5 PS4"></li><li><img src="https://img.finalfantasyxiv.com/lds/h/E/38lyWv84H59UEwldgCOGU2B9dM.png" width="33" height="39" alt="PC"></li><li><img src="https://img.finalfantasyxiv.com/lds/h/v/hyXqlwktN4v0EssRTzkbMf_7OQ.png" width="30" height="39" alt="Mac"></li><li class="last"><img src="https://img.finalfantasyxiv.com/lds/h/U/15QxPO___EcPlhMI9ydNRRxEY8.png" width="90" height="39" alt="STEAM"></li></ul><p class="l__footer__legal-area__text">“<i class="ps"></i>”, “PlayStation”, “<i class="ps5"></i>” and “<i class="ps4"></i>” are registered trademarks or trademarks of Sony Interactive Entertainment Inc.<br />Mac is a trademark of Apple Inc.<br />©2021 Valve Corporation. Steam and the Steam logo are trademarks and/or registered trademarks of Valve Corporation in the U.S. and/or other countries.</p></div><div class="l__footer__legal-area__box"><p class="l__footer__legal-area__copyright">© 2010 - 2022 <a href="https://square-enix-games.com/en_GB" target="_blank">SQUARE ENIX</a> CO., LTD. All Rights Reserved.<br>ENDWALKER, SHADOWBRINGERS, STORMBLOOD, HEAVENSWARD and A REALM REBORN are registered trademarks or trademarks of Square Enix Co., Ltd.<br />FINAL FANTASY, FINAL FANTASY XIV, FFXIV, SQUARE ENIX and the SQUARE ENIX logo are registered trademarks or trademarks of Square Enix Holdings Co., Ltd.<br>LOGO ILLUSTRATION: © 2010, 2014, 2016, 2018, 2021 YOSHITAKA AMANO</p></div></div></div></footer>
+
+
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-43364669-4"></script>
+<script>
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+
+	(function() {
+		var gtag_config = {
+			'link_attribution': true,
+			'custom_map': {
+				'dimension1': 'login',
+				'dimension2': 'theme',
+				'dimension3': 'mychara',
+				'dimension4': 'character_link'
+			},
+			'login': 'notloginuser',
+			'theme':  'white',
+		};
+
+
+		gtag('js', new Date());
+
+		gtag('config', 'UA-43364669-4', gtag_config);
+		gtag('config', 'UA-43364669-1', gtag_config);
+	})();
+</script>
+
+
+
+
+<script src="https://img.finalfantasyxiv.com/lds/pc/en-gb/js/i18n.js?1642399092"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/i/2ur_0e4qXk_NwNv0bGjrUHThCM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/g/uQNBgvCaabd4gw5kMpaT-psp1Q.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/b/RKD_bGx738E81TyiPQN4kGf-_Y.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/Z/wqo4GxX1wALdnxx6xOv38NxFVY.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/e/TSPHxkEhdcyaPMm0rpoBtk1dZA.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/P/O9-IKBqOphhkhVvm2QPrR9x5p4.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/u/AVbQMBsmCh3GU9JNbEtRUHDioc.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/8/b_tPmOnEw1tyr2dp2InkGxUlMA.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/Y/6WaukM6m3WFE2JXrCEb6tsknik.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/E/ImNUSWkI-O9dQP5ADa41RiGxGY.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/t/kQLYFR8rOESAOiyT9o2PsRnLq0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/C/q1cplyit_St5sY1BUgBKFuLapM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/s/Gt4XmT3a3nu52yKZPoVWcvrfFM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/A/LATlIIBarKmGFTTVid87k_GPFg.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/W/r-0ziwRwdsVj1lEyFHfmVyFgKw.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/piXyeCeUEtNAzCIq6jXoqNimzE.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/t/85HyWVlETnECMXo9l40HahjdO0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/OIfkF0BnyASNQ0RswButWbIKCU.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/U/jhEwPt7MvJy47-ExjjZ3lHW3qI.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/0/f52zA7ACWvjEMB1oWe8kfyGWH0.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/l/-_ePiHXNE_1t8LnRcmRAbhRME8.js"></script>
+<script src="https://www.youtube.com/iframe_api"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/P/MYGDtxveSuUwuhprm8oj1Hhuq8.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/M/it7tc9wvjlJJstEQUNjiModhdM.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/n/HMQm8_JEoqrSmuv5RmmKgTldGc.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/B/ElvNJhxzt4ULBYHMPrt3JiAKGU.js"></script>
+<script src="https://img.finalfantasyxiv.com/lds/h/d/UfPsCOe_Nl7ytqem4KWdsftkY0.js"></script>
+
+
+<div id="dialog_bg" style="opacity:0; visibility: hidden;"></div>
+<!-- dialog -->
+<div name="ldstDialog" class="overlay__area js__overlay" style="opacity:0; visibility: hidden; top: 0px">
+	<p class="overlay__text--icon"></p>
+
+	<div class="outbound_consent hide">
+		<input type="checkbox" name="outbound_consent" value="1" id="outbound_consent" class="form__checkbox">
+		<label for="outbound_consent" class="form__checkbox__label form__outbound">
+			Do not show this message again.
+		</label>
+	</div>
+
+	<!-- SIMPLE DIALOG -->
+	<a href="javascript:void(0);" class="js__dialog_btn btn__color--radius js__overlay_ok">Confirm</a>
+	<!-- //SIMPLE DIALOG -->
+	<!-- CONFIRM DIALOG -->
+	<ul class="js__dialog_btn overlay__btn js__overlay_btn">
+		<li><a href="javascript:void(0);" class="js__overlay_yes">Yes</a></li>
+		<li><a href="javascript:void(0);" class="js__overlay_no">No</a></li>
+	</ul>
+	<!-- //CONFIRM DIALOG -->
+</div>
+<!-- //dialog -->
+
+
+
+
+</body>
+</html>


### PR DESCRIPTION
This should allow us to reduce the number of GET requests made by leveraging the styles of the lodestone character root page.

We're seeing a significant number of players who present this scenario, so it should speed things up a decent bit.

Screenshot below of output from prod env, detailing the 404s this will suppress

![image](https://user-images.githubusercontent.com/3649078/150526965-313c6569-7aa4-48af-850b-08e445e4282f.png)
